### PR TITLE
feat: introduce warnings/traces fields and optional stderr prefix of attribute path

### DIFF
--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -204,6 +204,19 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
     });
 
     addFlag({
+        .longName = "log-attr-prefix",
+        .aliases = {},
+        .shortName = 0,
+        .description = "prefix stderr log lines with the attribute path that "
+                       "produced them",
+        .category = "",
+        .labels = {},
+        .handler = {&logAttrPrefix, true},
+        .completer = nullptr,
+        .experimentalFeature = std::nullopt,
+    });
+
+    addFlag({
         .longName = "expr",
         .aliases = {},
         .shortName = 'E',

--- a/src/eval-args.hh
+++ b/src/eval-args.hh
@@ -32,6 +32,7 @@ class MyArgs : virtual public nix::MixEvalArgs,
     bool showInputDrvs = false;
     bool constituents = false;
     bool noInstantiate = false;
+    bool logAttrPrefix = false;
     size_t nrWorkers = 1;
     size_t maxMemorySize = DEFAULT_MAX_MEMORY_SIZE;
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,7 +7,8 @@ common_src = [
   'worker.cc',
   'strings-portable.cc',
   'output-stream-lock.cc',
-  'daemon-settings.cc'
+  'daemon-settings.cc',
+  'prefix-logger.cc',
 ]
 
 common_deps = [

--- a/src/prefix-logger.cc
+++ b/src/prefix-logger.cc
@@ -1,0 +1,76 @@
+#include "prefix-logger.hh"
+
+#include <format>
+#include <memory>
+#include <nix/util/error.hh>
+#include <nix/util/logging.hh>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+PrefixLogger::PrefixLogger(std::unique_ptr<nix::Logger> wrapped)
+    : wrapped(std::move(wrapped)) {}
+
+void PrefixLogger::setAttrPath(std::string path) { attrPath = std::move(path); }
+
+void PrefixLogger::stop() { wrapped->stop(); }
+void PrefixLogger::pause() { wrapped->pause(); }
+void PrefixLogger::resume() { wrapped->resume(); }
+auto PrefixLogger::isVerbose() -> bool { return wrapped->isVerbose(); }
+
+void PrefixLogger::log(nix::Verbosity lvl, std::string_view msg) {
+    if (attrPath.empty()) {
+        wrapped->log(lvl, msg);
+    } else {
+        wrapped->log(lvl, std::format("{}: {}", attrPath, msg));
+    }
+}
+
+void PrefixLogger::logEI(const nix::ErrorInfo &info) {
+    if (attrPath.empty()) {
+        wrapped->logEI(info);
+    } else {
+        auto modified = info;
+        modified.traces.push_front(nix::Trace{
+            .pos = {},
+            .hint = nix::HintFmt("while evaluating attribute '%s'", attrPath),
+            .print = nix::TracePrint::Always,
+        });
+        wrapped->logEI(modified);
+    }
+}
+
+void PrefixLogger::startActivity(nix::ActivityId act, nix::Verbosity lvl,
+                                 nix::ActivityType type,
+                                 const std::string &text, const Fields &fields,
+                                 nix::ActivityId parent) {
+    if (attrPath.empty()) {
+        wrapped->startActivity(act, lvl, type, text, fields, parent);
+    } else {
+        wrapped->startActivity(act, lvl, type,
+                               std::format("{}: {}", attrPath, text), fields,
+                               parent);
+    }
+}
+
+void PrefixLogger::stopActivity(nix::ActivityId act) {
+    wrapped->stopActivity(act);
+}
+
+void PrefixLogger::result(nix::ActivityId act, nix::ResultType type,
+                          const Fields &fields) {
+    wrapped->result(act, type, fields);
+}
+
+void PrefixLogger::writeToStdout(std::string_view data) {
+    wrapped->writeToStdout(data);
+}
+
+auto PrefixLogger::ask(std::string_view msg) -> std::optional<char> {
+    return wrapped->ask(msg);
+}
+
+void PrefixLogger::setPrintBuildLogs(bool printBuildLogs) {
+    wrapped->setPrintBuildLogs(printBuildLogs);
+}

--- a/src/prefix-logger.cc
+++ b/src/prefix-logger.cc
@@ -4,15 +4,28 @@
 #include <memory>
 #include <nix/util/error.hh>
 #include <nix/util/logging.hh>
+#include <nix/util/terminal.hh>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 PrefixLogger::PrefixLogger(std::unique_ptr<nix::Logger> wrapped)
     : wrapped(std::move(wrapped)) {}
 
 void PrefixLogger::setAttrPath(std::string path) { attrPath = std::move(path); }
+
+auto PrefixLogger::drainLogs() -> Logs {
+    Logs logs{
+        .traces = std::move(traceBuffer),
+        .warnings = std::move(warningBuffer),
+    };
+    traceBuffer.clear();
+    warningBuffer.clear();
+    return logs;
+}
 
 void PrefixLogger::stop() { wrapped->stop(); }
 void PrefixLogger::pause() { wrapped->pause(); }
@@ -20,17 +33,24 @@ void PrefixLogger::resume() { wrapped->resume(); }
 auto PrefixLogger::isVerbose() -> bool { return wrapped->isVerbose(); }
 
 void PrefixLogger::log(nix::Verbosity lvl, std::string_view msg) {
-    if (attrPath.empty()) {
-        wrapped->log(lvl, msg);
-    } else {
+    if (!attrPath.empty()) {
+        auto filtered = nix::filterANSIEscapes(msg, true);
+        if (filtered.starts_with("trace:")) {
+            traceBuffer.emplace_back(std::move(filtered));
+        } else {
+            warningBuffer.emplace_back(std::move(filtered));
+        }
         wrapped->log(lvl, std::format("{}: {}", attrPath, msg));
+    } else {
+        wrapped->log(lvl, msg);
     }
 }
 
 void PrefixLogger::logEI(const nix::ErrorInfo &info) {
-    if (attrPath.empty()) {
-        wrapped->logEI(info);
-    } else {
+    if (!attrPath.empty()) {
+        std::ostringstream oss;
+        nix::showErrorInfo(oss, info, nix::loggerSettings.showTrace.get());
+        warningBuffer.emplace_back(nix::filterANSIEscapes(oss.str(), true));
         auto modified = info;
         modified.traces.push_front(nix::Trace{
             .pos = {},
@@ -38,6 +58,8 @@ void PrefixLogger::logEI(const nix::ErrorInfo &info) {
             .print = nix::TracePrint::Always,
         });
         wrapped->logEI(modified);
+    } else {
+        wrapped->logEI(info);
     }
 }
 

--- a/src/prefix-logger.cc
+++ b/src/prefix-logger.cc
@@ -12,8 +12,9 @@
 #include <utility>
 #include <vector>
 
-PrefixLogger::PrefixLogger(std::unique_ptr<nix::Logger> wrapped)
-    : wrapped(std::move(wrapped)) {}
+PrefixLogger::PrefixLogger(std::unique_ptr<nix::Logger> wrapped,
+                           bool prefixStderr)
+    : wrapped(std::move(wrapped)), prefixStderr(prefixStderr) {}
 
 void PrefixLogger::setAttrPath(std::string path) { attrPath = std::move(path); }
 
@@ -40,7 +41,11 @@ void PrefixLogger::log(nix::Verbosity lvl, std::string_view msg) {
         } else {
             warningBuffer.emplace_back(std::move(filtered));
         }
-        wrapped->log(lvl, std::format("{}: {}", attrPath, msg));
+        if (prefixStderr) {
+            wrapped->log(lvl, std::format("{}: {}", attrPath, msg));
+        } else {
+            wrapped->log(lvl, msg);
+        }
     } else {
         wrapped->log(lvl, msg);
     }
@@ -51,13 +56,18 @@ void PrefixLogger::logEI(const nix::ErrorInfo &info) {
         std::ostringstream oss;
         nix::showErrorInfo(oss, info, nix::loggerSettings.showTrace.get());
         warningBuffer.emplace_back(nix::filterANSIEscapes(oss.str(), true));
-        auto modified = info;
-        modified.traces.push_front(nix::Trace{
-            .pos = {},
-            .hint = nix::HintFmt("while evaluating attribute '%s'", attrPath),
-            .print = nix::TracePrint::Always,
-        });
-        wrapped->logEI(modified);
+        if (prefixStderr) {
+            auto modified = info;
+            modified.traces.push_front(nix::Trace{
+                .pos = {},
+                .hint =
+                    nix::HintFmt("while evaluating attribute '%s'", attrPath),
+                .print = nix::TracePrint::Always,
+            });
+            wrapped->logEI(modified);
+        } else {
+            wrapped->logEI(info);
+        }
     } else {
         wrapped->logEI(info);
     }
@@ -67,12 +77,12 @@ void PrefixLogger::startActivity(nix::ActivityId act, nix::Verbosity lvl,
                                  nix::ActivityType type,
                                  const std::string &text, const Fields &fields,
                                  nix::ActivityId parent) {
-    if (attrPath.empty()) {
-        wrapped->startActivity(act, lvl, type, text, fields, parent);
-    } else {
+    if (!attrPath.empty() && prefixStderr) {
         wrapped->startActivity(act, lvl, type,
                                std::format("{}: {}", attrPath, text), fields,
                                parent);
+    } else {
+        wrapped->startActivity(act, lvl, type, text, fields, parent);
     }
 }
 

--- a/src/prefix-logger.hh
+++ b/src/prefix-logger.hh
@@ -10,6 +10,7 @@
 class PrefixLogger : public nix::Logger {
     std::unique_ptr<nix::Logger> wrapped;
     std::string attrPath;
+    bool prefixStderr;
     std::vector<std::string> traceBuffer;
     std::vector<std::string> warningBuffer;
 
@@ -19,7 +20,8 @@ class PrefixLogger : public nix::Logger {
         std::vector<std::string> warnings;
     };
 
-    explicit PrefixLogger(std::unique_ptr<nix::Logger> wrapped);
+    explicit PrefixLogger(std::unique_ptr<nix::Logger> wrapped,
+                          bool prefixStderr);
 
     void setAttrPath(std::string path);
     auto drainLogs() -> Logs;

--- a/src/prefix-logger.hh
+++ b/src/prefix-logger.hh
@@ -5,15 +5,24 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 class PrefixLogger : public nix::Logger {
     std::unique_ptr<nix::Logger> wrapped;
     std::string attrPath;
+    std::vector<std::string> traceBuffer;
+    std::vector<std::string> warningBuffer;
 
   public:
+    struct Logs {
+        std::vector<std::string> traces;
+        std::vector<std::string> warnings;
+    };
+
     explicit PrefixLogger(std::unique_ptr<nix::Logger> wrapped);
 
     void setAttrPath(std::string path);
+    auto drainLogs() -> Logs;
 
     void stop() override;
     void pause() override;

--- a/src/prefix-logger.hh
+++ b/src/prefix-logger.hh
@@ -1,0 +1,36 @@
+#pragma once
+///@file
+
+#include <nix/util/logging.hh>
+
+#include <memory>
+#include <string>
+
+class PrefixLogger : public nix::Logger {
+    std::unique_ptr<nix::Logger> wrapped;
+    std::string attrPath;
+
+  public:
+    explicit PrefixLogger(std::unique_ptr<nix::Logger> wrapped);
+
+    void setAttrPath(std::string path);
+
+    void stop() override;
+    void pause() override;
+    void resume() override;
+    bool isVerbose() override;
+
+    void log(nix::Verbosity lvl, std::string_view msg) override;
+    void logEI(const nix::ErrorInfo &info) override;
+
+    void startActivity(nix::ActivityId act, nix::Verbosity lvl,
+                       nix::ActivityType type, const std::string &text,
+                       const Fields &fields, nix::ActivityId parent) override;
+    void stopActivity(nix::ActivityId act) override;
+    void result(nix::ActivityId act, nix::ResultType type,
+                const Fields &fields) override;
+
+    void writeToStdout(std::string_view data) override;
+    std::optional<char> ask(std::string_view msg) override;
+    void setPrintBuildLogs(bool printBuildLogs) override;
+};

--- a/src/response.cc
+++ b/src/response.cc
@@ -26,6 +26,12 @@ void adl_serializer<Response>::to_json(json &res, const Response &response) {
         {"attr", response.attr},
         {"attrPath", response.attrPath},
     };
+    if (!response.traces.empty()) {
+        res["traces"] = response.traces;
+    }
+    if (!response.warnings.empty()) {
+        res["warnings"] = response.warnings;
+    }
 
     std::visit(overloaded{
                    [&](const Response::Job &job) -> void {
@@ -51,11 +57,21 @@ auto adl_serializer<Response>::from_json(const json &_json) -> Response {
 
     auto attr = getString(valueAt(json, "attr"));
     std::vector<std::string> attrPath = valueAt(json, "attrPath");
+    std::vector<std::string> traces;
+    if (const auto *tracesJson = get(json, "traces")) {
+        traces = tracesJson->get<std::vector<std::string>>();
+    }
+    std::vector<std::string> warnings;
+    if (const auto *warningsJson = get(json, "warnings")) {
+        warnings = warningsJson->get<std::vector<std::string>>();
+    }
 
     auto makeResponse = [&](Response::Payload payload) -> Response {
         return Response{
             .attr = std::move(attr),
             .attrPath = std::move(attrPath),
+            .traces = std::move(traces),
+            .warnings = std::move(warnings),
             .payload = std::move(payload),
         };
     };

--- a/src/response.hh
+++ b/src/response.hh
@@ -24,6 +24,8 @@
 struct Response {
     std::string attr;                  // dot-joined attribute path
     std::vector<std::string> attrPath; // attribute path components
+    std::vector<std::string> traces;   // builtins.trace output during eval
+    std::vector<std::string> warnings; // warnings emitted during eval
 
     struct Job {
         Drv drv;

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -386,9 +386,13 @@ auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
         }
     }();
 
+    auto logs = prefixLogger->drainLogs();
+
     Response const response{
         .attr = attrPathS,
         .attrPath = path.get<std::vector<std::string>>(),
+        .traces = std::move(logs.traces),
+        .warnings = std::move(logs.warnings),
         .payload = std::move(payload),
     };
     nlohmann::json const reply = response;

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -366,13 +366,21 @@ auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
             auto msg = oss.str();
 
             // Print to STDERR for Hydra UI
-            std::cerr << attrPathS << ": " << msg << "\n";
+            if (args.logAttrPrefix) {
+                std::cerr << attrPathS << ": " << msg << "\n";
+            } else {
+                std::cerr << msg << "\n";
+            }
             return Response::Error{nix::filterANSIEscapes(msg, true)};
         } catch (const std::exception &e) {
             // FIXME: for some reason the catch block above doesn't trigger on
             // macOS (?)
             const auto *msg = e.what();
-            std::cerr << attrPathS << ": " << msg << '\n';
+            if (args.logAttrPrefix) {
+                std::cerr << attrPathS << ": " << msg << '\n';
+            } else {
+                std::cerr << msg << '\n';
+            }
             return Response::Error{
                 .error = nix::filterANSIEscapes(msg, true),
                 // Nix 2.34 throws `StackOverflowError` whreas before, Nix
@@ -416,7 +424,8 @@ void worker(
         args.lookupPath, evalStore, nix::fetchSettings, nix::evalSettings);
     nix::Bindings &autoArgs = *args.getAutoArgs(*state);
 
-    auto prefixLogger = std::make_unique<PrefixLogger>(std::move(nix::logger));
+    auto prefixLogger = std::make_unique<PrefixLogger>(std::move(nix::logger),
+                                                       args.logAttrPrefix);
     auto *prefixLoggerPtr = prefixLogger.get();
     nix::logger = std::move(prefixLogger);
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1,18 +1,20 @@
 // doesn't exist on macOS
 // IWYU pragma: no_include <bits/types/struct_rusage.h>
 
-#include <nix/expr/eval-error.hh>
-#include <nix/util/pos-idx.hh>
-#include <nix/util/terminal.hh>
-#include <nix/expr/attr-path.hh>
-#include <nix/store/local-fs-store.hh>
-#include <nix/store/globals.hh>
-#include <nix/cmd/installable-flake.hh>
-#include <nix/expr/value-to-json.hh>
-#include <sys/resource.h>
-#include <nlohmann/json.hpp>
 #include <cstdio>
 #include <iostream>
+#include <memory>
+#include <nix/cmd/installable-flake.hh>
+#include <nix/expr/attr-path.hh>
+#include <nix/expr/eval-error.hh>
+#include <nix/expr/value-to-json.hh>
+#include <nix/store/globals.hh>
+#include <nix/store/local-fs-store.hh>
+#include <nix/util/finally.hh>
+#include <nix/util/pos-idx.hh>
+#include <nix/util/terminal.hh>
+#include <nlohmann/json.hpp>
+#include <sys/resource.h>
 // NOLINTBEGIN(modernize-deprecated-headers)
 // misc-include-cleaner wants this header rather than the C++ version
 #include <stdlib.h>
@@ -47,6 +49,7 @@
 
 #include "worker.hh"
 #include "drv.hh"
+#include "prefix-logger.hh"
 #include "response.hh"
 #include "buffered-io.hh"
 #include "eval-args.hh"
@@ -318,7 +321,8 @@ auto shouldRestart(const MyArgs &args) -> bool {
 
 auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
                        nix::AutoCloseFD &toParent, nix::Bindings &autoArgs,
-                       nix::Value *vRoot, MyArgs &args) -> bool {
+                       nix::Value *vRoot, MyArgs &args,
+                       PrefixLogger *prefixLogger) -> bool {
     /* Wait for the collector to send us a job name. */
     if (tryWriteLine(toParent.get(), "next") < 0) {
         return false; // main process died
@@ -337,6 +341,8 @@ auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
 
     auto path = nlohmann::json::parse(line.substr(3));
     auto attrPathS = attrPathJoin(path);
+    prefixLogger->setAttrPath(attrPathS);
+    Finally const clearPrefix([&] -> void { prefixLogger->setAttrPath(""); });
 
     /* Evaluate it and send info back to the collector. */
     Response::Payload payload = [&]() -> Response::Payload {
@@ -360,13 +366,13 @@ auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
             auto msg = oss.str();
 
             // Print to STDERR for Hydra UI
-            std::cerr << msg << "\n";
+            std::cerr << attrPathS << ": " << msg << "\n";
             return Response::Error{nix::filterANSIEscapes(msg, true)};
         } catch (const std::exception &e) {
             // FIXME: for some reason the catch block above doesn't trigger on
             // macOS (?)
             const auto *msg = e.what();
-            std::cerr << msg << '\n';
+            std::cerr << attrPathS << ": " << msg << '\n';
             return Response::Error{
                 .error = nix::filterANSIEscapes(msg, true),
                 // Nix 2.34 throws `StackOverflowError` whreas before, Nix
@@ -406,12 +412,16 @@ void worker(
         args.lookupPath, evalStore, nix::fetchSettings, nix::evalSettings);
     nix::Bindings &autoArgs = *args.getAutoArgs(*state);
 
+    auto prefixLogger = std::make_unique<PrefixLogger>(std::move(nix::logger));
+    auto *prefixLoggerPtr = prefixLogger.get();
+    nix::logger = std::move(prefixLogger);
+
     nix::Value *vRoot = initializeRootValue(state, autoArgs, args);
 
     LineReader fromReader(fromParent.release());
 
     while (processJobRequest(*state, fromReader, toParent, autoArgs, vRoot,
-                             args)) {
+                             args, prefixLoggerPtr)) {
         // Continue processing jobs until we need to exit
     }
 

--- a/tests-functional/assets/flake.nix
+++ b/tests-functional/assets/flake.nix
@@ -54,6 +54,35 @@
         brokenPkgs = {
           brokenPackage = throw "this is an evaluation error";
         };
+        tracePkgs = {
+          traceJob = builtins.trace "trace message from traceJob" (derivation {
+            name = "traceJob";
+            inherit system;
+            builder = "/bin/sh";
+            args = [
+              "-c"
+              "echo done > $out"
+            ];
+          });
+        };
+        nestedPkgs = {
+          nested = {
+            recurseForDerivations = true;
+            deep = {
+              recurseForDerivations = true;
+              brokenJob = throw "nested evaluation error";
+              traceJob = builtins.trace "nested trace message" (derivation {
+                name = "nestedTraceJob";
+                inherit system;
+                builder = "/bin/sh";
+                args = [
+                  "-c"
+                  "echo done > $out"
+                ];
+              });
+            };
+          };
+        };
         infiniteRecursionPkgs = {
           packageWithInfiniteRecursion =
             let

--- a/tests-functional/assets/flake.nix
+++ b/tests-functional/assets/flake.nix
@@ -65,6 +65,20 @@
             ];
           });
         };
+        traceAndErrorPkgs = {
+          traceAndError = builtins.trace "trace before error" (throw "error after trace");
+        };
+        warnPkgs = {
+          warnJob = builtins.warn "warning from warnJob" (derivation {
+            name = "warnJob";
+            inherit system;
+            builder = "/bin/sh";
+            args = [
+              "-c"
+              "echo done > $out"
+            ];
+          });
+        };
         nestedPkgs = {
           nested = {
             recurseForDerivations = true;

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -623,6 +623,126 @@ def test_stderr_attr_prefix_nested_path() -> None:
     assert_stderr_has(res.stderr, "nested.deep.traceJob", "nested trace message")
 
 
+def test_json_traces_field() -> None:
+    """Test that builtins.trace output appears in the JSON traces field."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.tracePkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    result = json.loads(res.stdout)
+    assert result["attr"] == "traceJob"
+    assert "traces" in result
+    assert any("trace message from traceJob" in t for t in result["traces"])
+    assert "warnings" not in result
+
+
+def test_json_warnings_field() -> None:
+    """Test that builtins.warn output appears in the JSON warnings field."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.warnPkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    result = json.loads(res.stdout)
+    assert result["attr"] == "warnJob"
+    assert "warnings" in result
+    assert any("warning from warnJob" in w for w in result["warnings"])
+    assert "traces" not in result
+
+
+def test_json_error_no_traces() -> None:
+    """Test that error responses omit empty traces/warnings fields."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.brokenPkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+    )
+    result = json.loads(res.stdout)
+    assert "error" in result
+    assert "traces" not in result
+    assert "warnings" not in result
+
+
+def test_json_nested_traces() -> None:
+    """Test that nested attributes have per-attribute traces in JSON."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.nestedPkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+    )
+    results = [json.loads(r) for r in res.stdout.split("\n") if r]
+
+    trace_result = next(r for r in results if r.get("name") == "nestedTraceJob")
+    assert "traces" in trace_result
+    assert any("nested trace message" in t for t in trace_result["traces"])
+
+    error_result = next(r for r in results if "error" in r)
+    assert "traces" not in error_result
+
+
+def test_json_traces_with_error() -> None:
+    """Test that an error response can also carry traces from before the error."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.traceAndErrorPkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+    )
+    result = json.loads(res.stdout)
+    assert result["attr"] == "traceAndError"
+    assert "error" in result
+    assert "error after trace" in result["error"]
+    assert "traces" in result
+    assert any("trace before error" in t for t in result["traces"])
+
+
 def test_no_instantiate_mode() -> None:
     """Test that --no-instantiate flag works correctly"""
     with TemporaryDirectory() as tempdir:

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -523,6 +523,106 @@ def test_recursion_error() -> None:
         assert "max-call-depth exceeded" in result["error"]
 
 
+def assert_stderr_has(stderr: str, attr_path: str, message: str) -> None:
+    """Assert that stderr contains a block starting with ``attr_path: `` that contains *message*.
+
+    A block is the prefix line plus all subsequent indented continuation lines
+    (as produced by ``showErrorInfo``).
+    """
+    prefix = f"{attr_path}: "
+    lines = stderr.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith(prefix):
+            block_lines = [line]
+            for j in range(i + 1, len(lines)):
+                if lines[j] and not lines[j][0].isspace():
+                    break
+                block_lines.append(lines[j])
+            if message in "\n".join(block_lines):
+                return
+    relevant = [line for line in lines if attr_path in line or message in line]
+    raise AssertionError(
+        f"No stderr block starting with {prefix!r} contains {message!r}.\n"
+        f"Potentially relevant lines: {relevant!r}"
+    )
+
+
+def test_stderr_attr_prefix_on_eval_error() -> None:
+    """Test that stderr output from eval errors includes the attr path prefix."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.brokenPkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+    )
+    result = json.loads(res.stdout)
+    assert result["attr"] == "brokenPackage"
+    assert "this is an evaluation error" in result["error"]
+
+    assert_stderr_has(res.stderr, "brokenPackage", "this is an evaluation error")
+
+
+def test_stderr_attr_prefix_on_trace() -> None:
+    """Test that builtins.trace output includes the attr path prefix via PrefixLogger."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.tracePkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    result = json.loads(res.stdout)
+    assert result["attr"] == "traceJob"
+    assert result["name"] == "traceJob"
+
+    assert_stderr_has(res.stderr, "traceJob", "trace message from traceJob")
+
+
+def test_stderr_attr_prefix_nested_path() -> None:
+    """Test that nested attribute paths appear as full dotted paths in stderr prefixes."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.nestedPkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+    )
+    results = [json.loads(r) for r in res.stdout.split("\n") if r]
+
+    error_result = next(r for r in results if "error" in r)
+    assert error_result["attr"] == "nested.deep.brokenJob"
+    assert "nested evaluation error" in error_result["error"]
+
+    trace_result = next(r for r in results if r.get("name") == "nestedTraceJob")
+    assert trace_result["attr"] == "nested.deep.traceJob"
+
+    assert_stderr_has(res.stderr, "nested.deep.brokenJob", "nested evaluation error")
+    assert_stderr_has(res.stderr, "nested.deep.traceJob", "nested trace message")
+
+
 def test_no_instantiate_mode() -> None:
     """Test that --no-instantiate flag works correctly"""
     with TemporaryDirectory() as tempdir:

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -548,11 +548,12 @@ def assert_stderr_has(stderr: str, attr_path: str, message: str) -> None:
 
 
 def test_stderr_attr_prefix_on_eval_error() -> None:
-    """Test that stderr output from eval errors includes the attr path prefix."""
+    """Test that --log-attr-prefix adds the attr path prefix to stderr errors."""
     cmd = [
         str(BIN),
         "--workers",
         "1",
+        "--log-attr-prefix",
         *COMMON_FLAGS,
         "--flake",
         ".#legacyPackages.x86_64-linux.brokenPkgs",
@@ -571,11 +572,12 @@ def test_stderr_attr_prefix_on_eval_error() -> None:
 
 
 def test_stderr_attr_prefix_on_trace() -> None:
-    """Test that builtins.trace output includes the attr path prefix via PrefixLogger."""
+    """Test that --log-attr-prefix adds the attr path prefix to trace output."""
     cmd = [
         str(BIN),
         "--workers",
         "1",
+        "--log-attr-prefix",
         *COMMON_FLAGS,
         "--flake",
         ".#legacyPackages.x86_64-linux.tracePkgs",
@@ -594,12 +596,36 @@ def test_stderr_attr_prefix_on_trace() -> None:
     assert_stderr_has(res.stderr, "traceJob", "trace message from traceJob")
 
 
-def test_stderr_attr_prefix_nested_path() -> None:
-    """Test that nested attribute paths appear as full dotted paths in stderr prefixes."""
+def test_stderr_no_prefix_by_default() -> None:
+    """Test that stderr is NOT prefixed without --log-attr-prefix."""
     cmd = [
         str(BIN),
         "--workers",
         "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.tracePkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    for line in res.stderr.splitlines():
+        assert not line.startswith("traceJob: "), (
+            f"Stderr should not be prefixed without --log-attr-prefix: {line!r}"
+        )
+
+
+def test_stderr_attr_prefix_nested_path() -> None:
+    """Test that --log-attr-prefix works with nested dotted attribute paths."""
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        "--log-attr-prefix",
         *COMMON_FLAGS,
         "--flake",
         ".#legacyPackages.x86_64-linux.nestedPkgs",

--- a/tests-unit/data/response/error-with-warnings.json
+++ b/tests-unit/data/response/error-with-warnings.json
@@ -1,0 +1,11 @@
+{
+  "attr": "warned",
+  "attrPath": [
+    "warned"
+  ],
+  "error": "evaluation failed",
+  "fatal": false,
+  "warnings": [
+    "warning: deprecated feature used"
+  ]
+}

--- a/tests-unit/data/response/job-with-traces.json
+++ b/tests-unit/data/response/job-with-traces.json
@@ -1,0 +1,19 @@
+{
+  "attr": "traced",
+  "attrPath": [
+    "traced"
+  ],
+  "constituents": [],
+  "drvPath": "/nix/store/00000000000000000000000000000000-traced.drv",
+  "globConstituents": false,
+  "name": "traced",
+  "namedConstituents": [],
+  "outputs": {
+    "out": "/nix/store/00000000000000000000000000000000-traced"
+  },
+  "storeDir": "/nix/store",
+  "system": "x86_64-linux",
+  "traces": [
+    "trace: some debug info"
+  ]
+}

--- a/tests-unit/json.cc
+++ b/tests-unit/json.cc
@@ -219,6 +219,8 @@ INSTANTIATE_TEST_SUITE_P(
             Response{
                 .attr = "hello",
                 .attrPath = {"hello"},
+                .traces = {},
+                .warnings = {},
                 .payload =
                     Response::Job{
                         .drv =
@@ -247,6 +249,8 @@ INSTANTIATE_TEST_SUITE_P(
             Response{
                 .attr = "pkg",
                 .attrPath = {"pkg"},
+                .traces = {},
+                .warnings = {},
                 .payload =
                     Response::Job{
                         .drv =
@@ -280,6 +284,8 @@ INSTANTIATE_TEST_SUITE_P(
             Response{
                 .attr = "pkgs",
                 .attrPath = {"pkgs"},
+                .traces = {},
+                .warnings = {},
                 .payload = Response::Attrs{.attrs = {"foo", "bar", "baz"}},
             },
         },
@@ -288,6 +294,48 @@ INSTANTIATE_TEST_SUITE_P(
             Response{
                 .attr = "broken",
                 .attrPath = {"broken"},
+                .traces = {},
+                .warnings = {},
+                .payload = Response::Error{.error = "evaluation failed"},
+            },
+        },
+        std::pair{
+            "job-with-traces",
+            Response{
+                .attr = "traced",
+                .attrPath = {"traced"},
+                .traces = {"trace: some debug info"},
+                .warnings = {},
+                .payload =
+                    Response::Job{
+                        .drv =
+                            Drv{
+                                .name = "traced",
+                                .storeDir = "/nix/store",
+                                .system = "x86_64-linux",
+                                .drvPath = {"00000000000000000000000000000000-"
+                                            "traced.drv"},
+                                .outputs = {{"out",
+                                             nix::StorePath{
+                                                 "00000000000000000000000000000"
+                                                 "000-traced",
+                                             }}},
+                                .neededBuilds = {},
+                                .neededSubstitutes = {},
+                                .unknownPaths = {},
+                                .constituents = {},
+                            },
+                        .extraValue = std::nullopt,
+                    },
+            },
+        },
+        std::pair{
+            "error-with-warnings",
+            Response{
+                .attr = "warned",
+                .attrPath = {"warned"},
+                .traces = {},
+                .warnings = {"warning: deprecated feature used"},
                 .payload = Response::Error{.error = "evaluation failed"},
             },
         }));


### PR DESCRIPTION
> [!CAUTION]
>
> This is a work in progress and entirely vibe-coded.

The goal of the PR is to make it easier to analyze `nix-eval-jobs` logs for both people (i.e., by providing attribution of warnings/traces to the attribute paths which created them) and scripts (i.e., adding warnings/traces fields to the JSON objects being streamed out).

Summary

- Worker subprocesses now wrap `nix::logger` with a `PrefixLogger` decorator that can prepend attrPath: to all stderr log lines during evaluation, making interleaved multi-worker output attributable
- The stderr prefix is opt-in via `--log-attr-prefix` to avoid breaking existing scripts that parse stderr
- Evaluation log messages are buffered per-attribute and exposed as optional traces and warnings fields on the JSON output (omitted when empty), giving machine consumers access to `builtins.trace` and `builtins.warn output` that was previously only available on stderr
- builtins.trace output goes to traces; builtins.warn and structured warnings from logEI go to warnings; errors remain in the existing error field
