### PR TITLE
nix-eval-jobs: don't fork workers until a job is available

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -434,18 +434,7 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup) {
         std::optional<std::unique_ptr<LineReader>> fromReader_;
 
         while (true) {
-            // Check pending worker status before claiming a job
-            if (proc_.has_value()) {
-                auto line = checkWorkerStatus(fromReader_.value().get(),
-                                              proc_.value().get());
-                if (line == "restart") {
-                    // Reset worker
-                    proc_ = std::nullopt;
-                    fromReader_ = std::nullopt;
-                }
-            }
-
-            // Only fork after a job is claimed
+            // Claim a job before forking so over-provisioned workers stay idle
             auto maybeAttrPath = getNextJob(state_, wakeup);
             if (!maybeAttrPath.has_value()) {
                 if (proc_.has_value() &&
@@ -456,21 +445,20 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup) {
             }
             const auto &attrPath = maybeAttrPath.value();
 
-            // Fork if needed and wait for it to be ready
-            while (!proc_.has_value()) {
-                proc_ = std::make_unique<Proc>(worker);
-                fromReader_ =
-                    std::make_unique<LineReader>(proc_.value()->from.release());
-
+            // Ensure we have a worker that is ready for a job ("next")
+            while (true) {
+                if (!proc_.has_value()) {
+                    proc_ = std::make_unique<Proc>(worker);
+                    fromReader_ = std::make_unique<LineReader>(
+                        proc_.value()->from.release());
+                }
                 auto line = checkWorkerStatus(fromReader_.value().get(),
                                               proc_.value().get());
-                // New worker either sends "next" or `checkWorkerStatus` throws
-                if (line != "next") {
-                    throw nix::Error(
-                        "BUG: freshly forked worker sent '%s' instead of "
-                        "'next'",
-                        line);
+                if (line != "restart") {
+                    break;
                 }
+                proc_ = std::nullopt;
+                fromReader_ = std::nullopt;
             }
 
             if (tryWriteLine(proc_.value()->to.get(), "do " + attrPath.dump()) <

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -341,16 +341,13 @@ auto checkWorkerStatus(LineReader *fromReader, Proc *proc) -> std::string_view {
     return line;
 }
 
-auto getNextJob(nix::Sync<State> &state_, std::condition_variable &wakeup,
-                Proc *proc) -> std::optional<nlohmann::json> {
+auto getNextJob(nix::Sync<State> &state_, std::condition_variable &wakeup)
+    -> std::optional<nlohmann::json> {
     nlohmann::json attrPath;
     while (true) {
         nix::checkInterrupt();
         auto state(state_.lock());
         if ((state->todo.empty() && state->active.empty()) || state->exc) {
-            if (tryWriteLine(proc->to.get(), "exit") < 0) {
-                handleBrokenWorkerPipe(*proc, "sending exit");
-            }
             return std::nullopt;
         }
         if (!state->todo.empty()) {
@@ -437,30 +434,44 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup) {
         std::optional<std::unique_ptr<LineReader>> fromReader_;
 
         while (true) {
-            // Initialize worker if needed
-            if (!proc_.has_value()) {
-                proc_ = std::make_unique<Proc>(worker);
-            }
-            if (!fromReader_.has_value()) {
-                fromReader_ =
-                    std::make_unique<LineReader>(proc_.value()->from.release());
-            }
-
-            auto line = checkWorkerStatus(fromReader_.value().get(),
-                                          proc_.value().get());
-            if (line == "restart") {
-                // Reset worker
-                proc_ = std::nullopt;
-                fromReader_ = std::nullopt;
-                continue;
+            // Check pending worker status before claiming a job
+            if (proc_.has_value()) {
+                auto line = checkWorkerStatus(fromReader_.value().get(),
+                                              proc_.value().get());
+                if (line == "restart") {
+                    // Reset worker
+                    proc_ = std::nullopt;
+                    fromReader_ = std::nullopt;
+                }
             }
 
-            auto maybeAttrPath =
-                getNextJob(state_, wakeup, proc_.value().get());
+            // Only fork after a job is claimed
+            auto maybeAttrPath = getNextJob(state_, wakeup);
             if (!maybeAttrPath.has_value()) {
+                if (proc_.has_value() &&
+                    tryWriteLine(proc_.value()->to.get(), "exit") < 0) {
+                    handleBrokenWorkerPipe(*proc_.value(), "sending exit");
+                }
                 return;
             }
             const auto &attrPath = maybeAttrPath.value();
+
+            // Fork if needed and wait for it to be ready
+            while (!proc_.has_value()) {
+                proc_ = std::make_unique<Proc>(worker);
+                fromReader_ =
+                    std::make_unique<LineReader>(proc_.value()->from.release());
+
+                auto line = checkWorkerStatus(fromReader_.value().get(),
+                                              proc_.value().get());
+                // New worker either sends "next" or `checkWorkerStatus` throws
+                if (line != "next") {
+                    throw nix::Error(
+                        "BUG: freshly forked worker sent '%s' instead of "
+                        "'next'",
+                        line);
+                }
+            }
 
             if (tryWriteLine(proc_.value()->to.get(), "do " + attrPath.dump()) <
                 0) {

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -430,16 +430,15 @@ void updateJobQueue(nix::Sync<State> &state_, std::condition_variable &wakeup,
 
 void collector(nix::Sync<State> &state_, std::condition_variable &wakeup) {
     try {
-        std::optional<std::unique_ptr<Proc>> proc_;
-        std::optional<std::unique_ptr<LineReader>> fromReader_;
+        std::unique_ptr<Proc> proc;
+        std::unique_ptr<LineReader> fromReader;
 
         while (true) {
             // Claim a job before forking so over-provisioned workers stay idle
             auto maybeAttrPath = getNextJob(state_, wakeup);
             if (!maybeAttrPath.has_value()) {
-                if (proc_.has_value() &&
-                    tryWriteLine(proc_.value()->to.get(), "exit") < 0) {
-                    handleBrokenWorkerPipe(*proc_.value(), "sending exit");
+                if (proc && tryWriteLine(proc->to.get(), "exit") < 0) {
+                    handleBrokenWorkerPipe(*proc, "sending exit");
                 }
                 return;
             }
@@ -447,29 +446,26 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup) {
 
             // Ensure we have a worker that is ready for a job ("next")
             while (true) {
-                if (!proc_.has_value()) {
-                    proc_ = std::make_unique<Proc>(worker);
-                    fromReader_ = std::make_unique<LineReader>(
-                        proc_.value()->from.release());
+                if (!proc) {
+                    proc = std::make_unique<Proc>(worker);
+                    fromReader =
+                        std::make_unique<LineReader>(proc->from.release());
                 }
-                auto line = checkWorkerStatus(fromReader_.value().get(),
-                                              proc_.value().get());
+                auto line = checkWorkerStatus(fromReader.get(), proc.get());
                 if (line != "restart") {
                     break;
                 }
-                proc_ = std::nullopt;
-                fromReader_ = std::nullopt;
+                proc.reset();
+                fromReader.reset();
             }
 
-            if (tryWriteLine(proc_.value()->to.get(), "do " + attrPath.dump()) <
-                0) {
+            if (tryWriteLine(proc->to.get(), "do " + attrPath.dump()) < 0) {
                 auto msg = "sending attrPath '" + joinAttrPath(attrPath) + "'";
-                handleBrokenWorkerPipe(*proc_.value(), msg);
+                handleBrokenWorkerPipe(*proc, msg);
             }
 
-            auto newAttrs =
-                processWorkerResponse(fromReader_.value().get(), attrPath,
-                                      proc_.value().get(), state_);
+            auto newAttrs = processWorkerResponse(fromReader.get(), attrPath,
+                                                  proc.get(), state_);
 
             updateJobQueue(state_, wakeup, attrPath, newAttrs);
         }


### PR DESCRIPTION
while playing with https://github.com/nix-community/colmena/pull/340#event-27416514666 i was using --evaluator streaming (nix-eval-jobs) and set num workers to 99 and i observed high memory usage

it seems the collector forks the worker on startup and eagerly evaluates the root expression before asking for its first job

i think it'd be better to claim a job before forking (lazy in a sense) so that the over provisioned worker numbers don't cause penalty