### PR TITLE
fix: Forward log-format to workers

### DIFF
--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -7,6 +7,7 @@
 #include <nix/flake/lockfile.hh>
 #include <nix/util/canon-path.hh>
 #include <nix/main/common-args.hh>
+#include <nix/main/loggers.hh>
 #include <nix/cmd/common-eval-args.hh>
 #include <nix/util/source-accessor.hh>
 #include <nix/flake/flakeref.hh>
@@ -296,6 +297,19 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
         }},
         .completer = completePath,
         .experimentalFeature = std::nullopt,
+    });
+
+    addFlag({
+        .longName = "log-format",
+        .description =
+            "Set the format of log output; one of `raw`, `internal-json`, "
+            "`bar` or `bar-with-logs`.",
+        .category = "",
+        .labels = {"format"},
+        .handler = {[this](std::string format) -> void {
+            logFormat = format;
+            nix::setLogFormat(format);
+        }},
     });
 
     expectArg("expr", &releaseExpr);

--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -299,19 +299,6 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
         .experimentalFeature = std::nullopt,
     });
 
-    addFlag({
-        .longName = "log-format",
-        .description =
-            "Set the format of log output; one of `raw`, `internal-json`, "
-            "`bar` or `bar-with-logs`.",
-        .category = "",
-        .labels = {"format"},
-        .handler = {[this](std::string format) -> void {
-            logFormat = format;
-            nix::setLogFormat(format);
-        }},
-    });
-
     expectArg("expr", &releaseExpr);
 }
 

--- a/src/eval-args.hh
+++ b/src/eval-args.hh
@@ -32,6 +32,7 @@ class MyArgs : virtual public nix::MixEvalArgs,
     bool showInputDrvs = false;
     bool constituents = false;
     bool noInstantiate = false;
+    std::string logFormat = "raw";
     size_t nrWorkers = 1;
     size_t maxMemorySize = DEFAULT_MAX_MEMORY_SIZE;
 

--- a/src/eval-args.hh
+++ b/src/eval-args.hh
@@ -32,7 +32,6 @@ class MyArgs : virtual public nix::MixEvalArgs,
     bool showInputDrvs = false;
     bool constituents = false;
     bool noInstantiate = false;
-    std::string logFormat = "raw";
     size_t nrWorkers = 1;
     size_t maxMemorySize = DEFAULT_MAX_MEMORY_SIZE;
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -7,6 +7,7 @@
 #include <nix/expr/attr-path.hh>
 #include <nix/store/local-fs-store.hh>
 #include <nix/store/globals.hh>
+#include <nix/main/loggers.hh>
 #include <nix/cmd/installable-flake.hh>
 #include <nix/expr/value-to-json.hh>
 #include <sys/resource.h>
@@ -403,6 +404,11 @@ void worker(
     MyArgs &args,
     nix::AutoCloseFD &toParent, // NOLINT(bugprone-easily-swappable-parameters)
     nix::AutoCloseFD &fromParent) {
+
+    // nix::startProcess() resets nix::logger in every forked child (see
+    // src/libutil/unix/processes.cc). Reset it here to the format
+    // requested by the user.
+    nix::setLogFormat(args.logFormat);
 
     auto evalStore = nix_eval_jobs::openStore(args.evalStoreUrl);
     auto state = nix::make_ref<nix::EvalState>(

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -55,6 +55,7 @@
 
 namespace nix {
 struct Expr;
+extern LogFormat defaultLogFormat;
 } // namespace nix
 
 namespace {
@@ -405,10 +406,8 @@ void worker(
     nix::AutoCloseFD &toParent, // NOLINT(bugprone-easily-swappable-parameters)
     nix::AutoCloseFD &fromParent) {
 
-    // nix::startProcess() resets nix::logger in every forked child (see
-    // src/libutil/unix/processes.cc). Reset it here to the format
-    // requested by the user.
-    nix::setLogFormat(args.logFormat);
+    /* nix::startProcess() resets nix::logger in forked children. */
+    nix::setLogFormat(nix::defaultLogFormat);
 
     auto evalStore = nix_eval_jobs::openStore(args.evalStoreUrl);
     auto state = nix::make_ref<nix::EvalState>(

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -738,3 +738,46 @@ def test_fod_with_uncached_input_issue413(tmp_path: Path, scheme: str) -> None:
     jobs = [json.loads(line) for line in res.splitlines() if line]
     fod = next(job for job in jobs if job["attr"] == "fod")
     assert fod["cacheStatus"] == "cached", fod
+
+
+def test_worker_log_format_survives_fork(tmp_path: Path) -> None:
+    """--log-format internal-json must apply inside forked worker processes.
+    By default, nix::startProcess() resets the global nix::logger to a plain
+    logger in every forked child, regardless of --log-format (see
+    src/libutil/unix/processes.cc).
+    """
+    env = _hermetic_nix_env(tmp_path)
+    assets = TEST_ROOT.joinpath("assets")
+
+    res = subprocess.run(
+        [
+            str(BIN),
+            "--gc-roots-dir",
+            str(tmp_path / "gc"),
+            *COMMON_FLAGS,
+            "--log-format",
+            "internal-json",
+            "--option",
+            "substituters",
+            "",
+            "--flake",
+            ".#hydraJobs",
+        ],
+        cwd=assets,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    stderr_lines = [line for line in res.stderr.splitlines() if line]
+    assert stderr_lines, "expected nix-eval-jobs to log something on stderr"
+
+    # Every line on stderr should be internal-json framed once --log-format
+    # is requested -- including inside the forked worker.
+    non_json_lines = [line for line in stderr_lines if not line.startswith("@nix ")]
+    assert not non_json_lines, f"stderr contained non-internal-json lines: {non_json_lines}"
+
+    for line in stderr_lines:
+        # Must be valid, well-formed internal-json, not just "starts with
+        # @nix " by coincidence.
+        json.loads(line[len("@nix ") :])

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -741,11 +741,6 @@ def test_fod_with_uncached_input_issue413(tmp_path: Path, scheme: str) -> None:
 
 
 def test_worker_log_format_survives_fork(tmp_path: Path) -> None:
-    """--log-format internal-json must apply inside forked worker processes.
-    By default, nix::startProcess() resets the global nix::logger to a plain
-    logger in every forked child, regardless of --log-format (see
-    src/libutil/unix/processes.cc).
-    """
     env = _hermetic_nix_env(tmp_path)
     assets = TEST_ROOT.joinpath("assets")
 
@@ -772,12 +767,7 @@ def test_worker_log_format_survives_fork(tmp_path: Path) -> None:
     stderr_lines = [line for line in res.stderr.splitlines() if line]
     assert stderr_lines, "expected nix-eval-jobs to log something on stderr"
 
-    # Every line on stderr should be internal-json framed once --log-format
-    # is requested -- including inside the forked worker.
     non_json_lines = [line for line in stderr_lines if not line.startswith("@nix ")]
     assert not non_json_lines, f"stderr contained non-internal-json lines: {non_json_lines}"
-
     for line in stderr_lines:
-        # Must be valid, well-formed internal-json, not just "starts with
-        # @nix " by coincidence.
         json.loads(line[len("@nix ") :])


### PR DESCRIPTION
Disclaimer: This PR was assisted by Claude Sonnet 5

Bug: When using `--log-format=internal-json`: Any logs in the parent correctly produce the JSON-formatted logs, but logs produced by children revert to the default logger implementation.

Supposedly because of [this line in upstream nix](https://github.com/NixOS/nix/blob/master/src/libutil/unix/processes.cc#L239): Worker loggers are reset, and do not respect the `log-format` setting from the parent process. I think this is a bug in upstream, but there's not a great way to reproduce it with `nix` alone. I'll open a PR there too, so no need to merge this pending that discussion--I'm just providing the patch I'm using on nix-eval-jobs to work around the issue in the meantime.

This PR:

- Adds `log-format` parameter to nix-eval-jobs, and resets the logger to this value when forking a worker.
- Adds a functional test for this behavior.