### PR TITLE
collector: don't write exit to a worker that announced restart

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -465,7 +465,12 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup,
             // Claim a job before forking so over-provisioned workers stay idle
             auto maybeAttrPath = getNextJob(state_, wakeup);
             if (!maybeAttrPath.has_value()) {
-                if (proc && tryWriteLine(proc->to.get(), "exit") < 0) {
+                /* A worker whose pending status line is "restart" has
+                   already closed its pipe and is exiting on its own. */
+                if (proc &&
+                    checkWorkerStatus(fromReader.get(), proc.get()) !=
+                        "restart" &&
+                    tryWriteLine(proc->to.get(), "exit") < 0) {
                     handleBrokenWorkerPipe(*proc, "sending exit");
                 }
                 return;

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -150,7 +150,8 @@ struct Proc {
                     };
                     // Don't forget to print it into the STDERR log, this is
                     // what's shown in the Hydra UI.
-                    if (tryWriteLine(toFd->get(), "restart") < 0) {
+                    if (tryWriteLine(toFd->get(), std::string(MSG_RESTART)) <
+                        0) {
                         return; // main process died
                     }
                 }
@@ -328,7 +329,7 @@ auto checkWorkerStatus(LineReader *fromReader, Proc *proc) -> std::string_view {
     if (line.empty()) {
         handleBrokenWorkerPipe(*proc, "checking worker process");
     }
-    if (line != "next" && line != "restart") {
+    if (line != MSG_NEXT && line != MSG_RESTART) {
         try {
             auto json = nlohmann::json::parse(line);
             throw nix::Error("worker error: %s", std::string(json["error"]));
@@ -465,19 +466,20 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup,
             // Claim a job before forking so over-provisioned workers stay idle
             auto maybeAttrPath = getNextJob(state_, wakeup);
             if (!maybeAttrPath.has_value()) {
-                /* A worker whose pending status line is "restart" has
-                   already closed its pipe and is exiting on its own. */
+                /* A worker whose pending status line is MSG_RESTART
+                   has already closed its pipe and is exiting on its
+                   own. */
                 if (proc &&
                     checkWorkerStatus(fromReader.get(), proc.get()) !=
-                        "restart" &&
-                    tryWriteLine(proc->to.get(), "exit") < 0) {
+                        MSG_RESTART &&
+                    tryWriteLine(proc->to.get(), std::string(MSG_EXIT)) < 0) {
                     handleBrokenWorkerPipe(*proc, "sending exit");
                 }
                 return;
             }
             const auto &attrPath = maybeAttrPath.value();
 
-            // Ensure we have a worker that is ready for a job ("next")
+            // Ensure we have a worker that is ready for a job
             while (true) {
                 if (!proc) {
                     proc = std::make_unique<Proc>(worker);
@@ -485,14 +487,15 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup,
                         std::make_unique<LineReader>(proc->from.release());
                 }
                 auto line = checkWorkerStatus(fromReader.get(), proc.get());
-                if (line != "restart") {
+                if (line != MSG_RESTART) {
                     break;
                 }
                 proc.reset();
                 fromReader.reset();
             }
 
-            if (tryWriteLine(proc->to.get(), "do " + attrPath.dump()) < 0) {
+            if (tryWriteLine(proc->to.get(),
+                             std::string(MSG_DO) + attrPath.dump()) < 0) {
                 auto msg = "sending attrPath '" + joinAttrPath(attrPath) + "'";
                 handleBrokenWorkerPipe(*proc, msg);
             }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -325,22 +325,22 @@ auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
                        nix::AutoCloseFD &toParent, nix::Bindings &autoArgs,
                        nix::Value *vRoot, MyArgs &args) -> bool {
     /* Wait for the collector to send us a job name. */
-    if (tryWriteLine(toParent.get(), "next") < 0) {
+    if (tryWriteLine(toParent.get(), std::string(MSG_NEXT)) < 0) {
         return false; // main process died
     }
 
     auto line = fromReader.readLine();
-    if (line == "exit") {
+    if (line == MSG_EXIT) {
         return false;
     }
 
-    if (!nix::hasPrefix(line, "do ")) {
+    if (!nix::hasPrefix(line, MSG_DO)) {
         std::cerr << "worker error: received invalid command '" << line
                   << "'\n";
         abort();
     }
 
-    auto path = nlohmann::json::parse(line.substr(3));
+    auto path = nlohmann::json::parse(line.substr(MSG_DO.size()));
     auto attrPathS = attrPathJoin(path);
 
     /* Evaluate it and send info back to the collector. */
@@ -423,7 +423,7 @@ void worker(
         // Continue processing jobs until we need to exit
     }
 
-    if (tryWriteLine(toParent.get(), "restart") < 0) {
+    if (tryWriteLine(toParent.get(), std::string(MSG_RESTART)) < 0) {
         return; // main process died
     };
 }

--- a/src/worker.hh
+++ b/src/worker.hh
@@ -1,6 +1,8 @@
 #pragma once
 ///@file
 
+#include <string_view>
+
 #include "eval-args.hh"
 
 class MyArgs;
@@ -11,6 +13,12 @@ class Bindings;
 class EvalState;
 template <typename T> class ref;
 } // namespace nix
+
+/* Messages between eval worker and collector */
+constexpr std::string_view MSG_NEXT = "next";
+constexpr std::string_view MSG_RESTART = "restart";
+constexpr std::string_view MSG_EXIT = "exit";
+constexpr std::string_view MSG_DO = "do ";
 
 void worker(MyArgs &args, nix::AutoCloseFD &toParent,
             nix::AutoCloseFD &fromParent);

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -771,3 +771,26 @@ def test_worker_log_format_survives_fork(tmp_path: Path) -> None:
     assert not non_json_lines, f"stderr contained non-internal-json lines: {non_json_lines}"
     for line in stderr_lines:
         json.loads(line[len("@nix ") :])
+
+
+def test_worker_restart_on_last_job_exits_cleanly() -> None:
+    with TemporaryDirectory() as tempdir:
+        res = subprocess.run(
+            [
+                str(BIN),
+                "--gc-roots-dir",
+                tempdir,
+                "--workers",
+                "1",
+                "--max-memory-size",
+                "1",
+                *COMMON_FLAGS,
+                "ci.nix",
+            ],
+            cwd=TEST_ROOT.joinpath("assets"),
+            text=True,
+            capture_output=True,
+        )
+        results = [json.loads(r) for r in res.stdout.split("\n") if r]
+        assert len(results) == 4
+        assert res.returncode == 0, res.stderr


### PR DESCRIPTION
Since 1a37e338 the collector claims a job before reading the worker's pending status line. On shutdown the pending `restart` of a worker that crossed `--max-memory-size` on the last job was never read.

Fixes #433