### PR TITLE
workers: spawn via fork+exec instead of plain fork

### DIFF
--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -299,6 +299,15 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
         .experimentalFeature = std::nullopt,
     });
 
+    const std::string internalCategory = "Internal flags";
+    addFlag({
+        .longName = "worker",
+        .description = "run as an evaluation worker process",
+        .category = internalCategory,
+        .handler = {&runAsWorker, true},
+    });
+    hiddenCategories.insert(internalCategory);
+
     expectArg("expr", &releaseExpr);
 }
 

--- a/src/eval-args.hh
+++ b/src/eval-args.hh
@@ -32,6 +32,7 @@ class MyArgs : virtual public nix::MixEvalArgs,
     bool showInputDrvs = false;
     bool constituents = false;
     bool noInstantiate = false;
+    bool runAsWorker = false;
     size_t nrWorkers = 1;
     size_t maxMemorySize = DEFAULT_MAX_MEMORY_SIZE;
 

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -10,7 +10,6 @@
 #include <csignal>
 #include <cstdlib>
 #include <cstring>
-#include <curl/curl.h>
 #include <exception>
 #include <filesystem>
 #include <functional>
@@ -47,6 +46,9 @@
 #include <optional>
 #include <pthread.h>
 #include <set>
+#include <fcntl.h>
+#include <nix/util/current-process.hh>
+#include <spawn.h>
 #include <span>
 #include <string>
 #include <string_view>
@@ -66,11 +68,34 @@
 #include "store.hh"
 #include "cache-status-resolver.hh"
 
+/* Not declared by <unistd.h> on all platforms. */
+extern "C" char **environ; // NOLINT(readability-redundant-declaration)
+
 namespace {
 MyArgs myArgs; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-using Processor = std::function<void(MyArgs &myArgs, nix::AutoCloseFD &toFd,
-                                     nix::AutoCloseFD &fromFd)>;
+void runWorker() {
+    nix::AutoCloseFD toParent(WORKER_OUT_FD);
+    nix::AutoCloseFD fromParent(WORKER_IN_FD);
+    nix::logger->log(nix::lvlDebug,
+                     nix::fmt("created worker process %d", getpid()));
+    try {
+        worker(myArgs, toParent, fromParent);
+    } catch (nix::Error &e) {
+        nlohmann::json err;
+        const auto &msg = e.msg();
+        err["error"] = nix::filterANSIEscapes(msg, true);
+        // Also print it to the STDERR log; this is what's shown in
+        // the Hydra UI.
+        nix::logger->log(nix::lvlError, msg);
+        if (tryWriteLine(toParent.get(), err.dump()) < 0) {
+            return; // main process died
+        }
+        if (tryWriteLine(toParent.get(), std::string(MSG_RESTART)) < 0) {
+            return; // main process died
+        }
+    }
+}
 
 void handleConstituents(std::map<std::string, nlohmann::json> &jobs,
                         const MyArgs &args) {
@@ -114,7 +139,11 @@ void handleConstituents(std::map<std::string, nlohmann::json> &jobs,
         resolveNamedConstituents(jobs));
 }
 
-/* Auto-cleanup of fork's process and fds. */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+std::vector<std::string> savedArgs;
+
+/* Worker process: fork + exec of our own binary with --worker, so no
+   thread-dependent state (logger, FileTransfer) survives into it. */
 struct Proc {
     nix::AutoCloseFD to, from;
     nix::Pid pid;
@@ -124,39 +153,49 @@ struct Proc {
     auto operator=(const Proc &) -> Proc & = delete;
     auto operator=(Proc &&) -> Proc & = delete;
 
-    explicit Proc(const Processor &proc) {
+    Proc() {
         nix::Pipe toPipe;
         nix::Pipe fromPipe;
         toPipe.create();
         fromPipe.create();
-        auto childPid = startProcess(
-            [&,
-             toFd{std::make_shared<nix::AutoCloseFD>(
-                 std::move(fromPipe.writeSide))},
-             fromFd{std::make_shared<nix::AutoCloseFD>(
-                 std::move(toPipe.readSide))}]() -> void {
-                nix::logger->log(
-                    nix::lvlDebug,
-                    nix::fmt("created worker process %d", getpid()));
-                try {
-                    proc(myArgs, *toFd, *fromFd);
-                } catch (nix::Error &e) {
-                    nlohmann::json err;
-                    const auto &msg = e.msg();
-                    err["error"] = nix::filterANSIEscapes(msg, true);
-                    nix::logger->log(nix::lvlError, msg);
-                    if (tryWriteLine(toFd->get(), err.dump()) < 0) {
-                        return; // main process died
-                    };
-                    // Don't forget to print it into the STDERR log, this is
-                    // what's shown in the Hydra UI.
-                    if (tryWriteLine(toFd->get(), std::string(MSG_RESTART)) <
-                        0) {
-                        return; // main process died
-                    }
-                }
-            },
-            nix::ProcessOptions{.allowVfork = false});
+
+        const std::string selfExe =
+            nix::getSelfExe().value_or(savedArgs.front()).string();
+        std::vector<std::string> args = savedArgs;
+        args.emplace_back("--worker");
+        std::vector<char *> execArgv;
+        execArgv.reserve(args.size() + 1);
+        for (auto &arg : args) {
+            execArgv.push_back(arg.data());
+        }
+        execArgv.push_back(nullptr);
+
+        /* Dup above the target fds so the adddup2 sources cannot
+           collide with WORKER_OUT_FD/WORKER_IN_FD. */
+        constexpr int minFreeFd = WORKER_IN_FD + 1;
+        const nix::AutoCloseFD outFd(
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+            fcntl(fromPipe.writeSide.get(), F_DUPFD, minFreeFd));
+        const nix::AutoCloseFD inFd(
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+            fcntl(toPipe.readSide.get(), F_DUPFD, minFreeFd));
+        if (!outFd || !inFd) {
+            throw nix::SysError("duplicating worker pipe fds");
+        }
+
+        posix_spawn_file_actions_t fileActions;
+        posix_spawn_file_actions_init(&fileActions);
+        posix_spawn_file_actions_adddup2(&fileActions, outFd.get(),
+                                         WORKER_OUT_FD);
+        posix_spawn_file_actions_adddup2(&fileActions, inFd.get(),
+                                         WORKER_IN_FD);
+        pid_t childPid = -1;
+        const int err = posix_spawn(&childPid, selfExe.c_str(), &fileActions,
+                                    nullptr, execArgv.data(), environ);
+        posix_spawn_file_actions_destroy(&fileActions);
+        if (err != 0) {
+            throw nix::SysError(err, "spawning worker process");
+        }
 
         to = std::move(toPipe.writeSide);
         from = std::move(fromPipe.readSide);
@@ -482,7 +521,7 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup,
             // Ensure we have a worker that is ready for a job
             while (true) {
                 if (!proc) {
-                    proc = std::make_unique<Proc>(worker);
+                    proc = std::make_unique<Proc>();
                     fromReader =
                         std::make_unique<LineReader>(proc->from.release());
                 }
@@ -541,21 +580,8 @@ void validateIncompatibleFlags(const MyArgs &args) {
 } // namespace
 
 auto main(int argc, char **argv) -> int {
-    /* We are doing the garbage collection by killing forks */
+    /* We are doing the garbage collection by restarting workers */
     setenv("GC_DONT_GC", "1", 1); // NOLINT(concurrency-mt-unsafe)
-
-    /* Because of an objc quirk[1], calling curl_global_init for the first time
-       after fork() will always result in a crash.
-       Up until now the solution has been to set
-       OBJC_DISABLE_INITIALIZE_FORK_SAFETY for every nix process to ignore that
-       error. Instead of working around that error we address it at the core -
-       by calling curl_global_init here, which should mean curl will already
-       have been initialized by the time we try to do so in a forked process.
-
-       [1]
-       https://github.com/apple-oss-distributions/objc4/blob/01edf1705fbc3ff78a423cd21e03dfc21eb4d780/runtime/objc-initialize.mm#L614-L636
-    */
-    curl_global_init(CURL_GLOBAL_ALL);
 
     auto args = std::span(argv, argc);
 
@@ -610,6 +636,13 @@ auto main(int argc, char **argv) -> int {
         if (myArgs.showTrace) {
             nix::loggerSettings.showTrace.assign(true);
         }
+
+        if (myArgs.runAsWorker) {
+            runWorker();
+            return;
+        }
+
+        savedArgs.assign(args.begin(), args.end());
 
         nix::Sync<State> state_;
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -7,7 +7,6 @@
 #include <nix/expr/attr-path.hh>
 #include <nix/store/local-fs-store.hh>
 #include <nix/store/globals.hh>
-#include <nix/main/loggers.hh>
 #include <nix/cmd/installable-flake.hh>
 #include <nix/expr/value-to-json.hh>
 #include <sys/resource.h>
@@ -55,7 +54,6 @@
 
 namespace nix {
 struct Expr;
-extern LogFormat defaultLogFormat;
 } // namespace nix
 
 namespace {
@@ -405,9 +403,6 @@ void worker(
     MyArgs &args,
     nix::AutoCloseFD &toParent, // NOLINT(bugprone-easily-swappable-parameters)
     nix::AutoCloseFD &fromParent) {
-
-    /* nix::startProcess() resets nix::logger in forked children. */
-    nix::setLogFormat(nix::defaultLogFormat);
 
     auto evalStore = nix_eval_jobs::openStore(args.evalStoreUrl);
     auto state = nix::make_ref<nix::EvalState>(

--- a/src/worker.hh
+++ b/src/worker.hh
@@ -20,5 +20,9 @@ constexpr std::string_view MSG_RESTART = "restart";
 constexpr std::string_view MSG_EXIT = "exit";
 constexpr std::string_view MSG_DO = "do ";
 
+/* Pipe ends inherited by the exec'ed worker process. */
+constexpr int WORKER_OUT_FD = 3; // worker -> collector
+constexpr int WORKER_IN_FD = 4;  // collector -> worker
+
 void worker(MyArgs &args, nix::AutoCloseFD &toParent,
             nix::AutoCloseFD &fromParent);

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import base64
 import contextlib
 import functools
+import hashlib
 import http.server
 import json
 import os
@@ -794,3 +796,61 @@ def test_worker_restart_on_last_job_exits_cleanly() -> None:
         results = [json.loads(r) for r in res.stdout.split("\n") if r]
         assert len(results) == 4
         assert res.returncode == 0, res.stderr
+
+
+def test_fetchers_survive_worker_restart(tmp_path: Path) -> None:
+    """A worker forked after the resolver's first probe (here: forced by
+    --max-memory-size 1) must not inherit an initialised global
+    FileTransfer, or its fetchers hang."""
+    env = _hermetic_nix_env(tmp_path)
+    served = tmp_path / "served"
+    served.mkdir()
+    sources = {}
+    for name in ("one", "two"):
+        data = f"fetched {name}\n".encode()
+        served.joinpath(name).write_bytes(data)
+        sources[name] = base64.b64encode(hashlib.sha256(data).digest()).decode()
+    served.joinpath("nix-cache-info").write_text(
+        f"StoreDir: {env['NIX_STORE_DIR']}\nWantMassQuery: 1\nPriority: 40\n"
+    )
+
+    with _http_server(served) as url:
+        jobs = "\n".join(
+            f"""
+          job-{name} = derivation {{
+            name = "restart-fetch-{name}";
+            system = builtins.currentSystem;
+            builder = "/bin/sh";
+            src = builtins.fetchurl {{
+              url = "{url}/{name}";
+              sha256 = "sha256-{digest}";
+            }};
+          }};"""
+            for name, digest in sources.items()
+        )
+        res = subprocess.run(
+            [
+                str(BIN),
+                "--workers",
+                "1",
+                "--max-memory-size",
+                "1",
+                "--check-cache-status",
+                "--option",
+                "substituters",
+                url,
+                "--option",
+                "require-sigs",
+                "false",
+                "--expr",
+                f"{{ {jobs} }}",
+            ],
+            env=env,
+            text=True,
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+
+    results = [json.loads(line) for line in res.stdout.splitlines() if line]
+    assert len(results) == 2


### PR DESCRIPTION
We had way to many fork bugs over the years especially on macOS. Instead we now do a clean exec to reset all the global state. This gets rid of misbehaving process-global FileTransfer (#430) after a worker restart by constructions and also fixes the logger (#431) as well as curl workaround that we do on macOS.

Fixes #430