### PR TITLE
collector: pre-lock the flake and pass it to the workers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
                     self'.packages.nix-eval-jobs
                     pkgs.python3.pkgs.pytest
                     pkgs.nix
+                    pkgs.gitMinimal
                   ];
                 }
                 ''

--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -7,7 +7,6 @@
 #include <nix/flake/lockfile.hh>
 #include <nix/util/canon-path.hh>
 #include <nix/main/common-args.hh>
-#include <nix/main/loggers.hh>
 #include <nix/cmd/common-eval-args.hh>
 #include <nix/util/source-accessor.hh>
 #include <nix/flake/flakeref.hh>
@@ -302,6 +301,7 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
     const std::string internalCategory = "Internal flags";
     addFlag({
         .longName = "worker",
+        .aliases = {},
         .description = "run as an evaluation worker process",
         .category = internalCategory,
         .handler = {&runAsWorker, true},

--- a/src/eval-args.hh
+++ b/src/eval-args.hh
@@ -33,6 +33,8 @@ class MyArgs : virtual public nix::MixEvalArgs,
     bool constituents = false;
     bool noInstantiate = false;
     bool runAsWorker = false;
+    /* Set from the collector's config message, not a flag. */
+    std::string lockedFlakeAttrs;
     size_t nrWorkers = 1;
     size_t maxMemorySize = DEFAULT_MAX_MEMORY_SIZE;
 

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -141,6 +141,9 @@ void handleConstituents(std::map<std::string, nlohmann::json> &jobs,
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::vector<std::string> savedArgs;
+/* First message sent to every worker. */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+std::string workerConfig = "{}";
 
 /* Worker process: fork + exec of our own binary with --worker, so no
    thread-dependent state (logger, FileTransfer) survives into it. */
@@ -198,6 +201,9 @@ struct Proc {
         }
 
         to = std::move(toPipe.writeSide);
+        if (tryWriteLine(to.get(), workerConfig) < 0) {
+            throw nix::SysError("sending config to worker process");
+        }
         from = std::move(fromPipe.readSide);
         pid = childPid;
     }
@@ -650,6 +656,13 @@ auto main(int argc, char **argv) -> int {
            workers would otherwise race to create fetcher-cache-v4.sqlite and
            fail with "unable to open database file". Open it once here. */
         nix::fetchSettings.getCache();
+
+        if (myArgs.flake) {
+            if (auto lockedAttrs = prefetchFlake(myArgs)) {
+                workerConfig =
+                    nlohmann::json{{"lockedFlake", *lockedAttrs}}.dump();
+            }
+        }
 
         auto cacheStatusResolver = makeCacheStatusResolver(myArgs, state_);
         auto *cacheStatusResolverPtr =

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -24,6 +24,7 @@
 #include <nix/util/error.hh>
 #include <nix/expr/eval.hh>
 #include <nix/util/file-system.hh>
+#include <nix/fetchers/attrs.hh>
 #include <nix/flake/flakeref.hh>
 #include <nix/flake/flake.hh>
 #include <nix/expr/get-drvs.hh>
@@ -86,13 +87,23 @@ auto releaseExprTopLevelValue(nix::EvalState &state, nix::Bindings &autoArgs,
     return vRoot;
 }
 
-auto evaluateFlake(const nix::ref<nix::EvalState> &state,
-                   const std::string &releaseExpr,
-                   const nix::flake::LockFlags &lockFlags) -> nix::Value * {
+auto evaluateFlake(const nix::ref<nix::EvalState> &state, const MyArgs &args)
+    -> nix::Value * {
     auto [flakeRef, fragment, outputSpec] =
         nix::parseFlakeRefWithFragmentAndExtendedOutputsSpec(
-            nix::fetchSettings, releaseExpr,
+            nix::fetchSettings, args.releaseExpr,
             nix::absPath(std::filesystem::path(".")));
+    const auto &lockFlags = args.lockFlags;
+
+    /* The collector passes the flakeref it already locked and fetched:
+       final + narHash lets the fetcher skip the fetch lock entirely
+       (issue #432). */
+    if (!args.lockedFlakeAttrs.empty()) {
+        flakeRef = nix::FlakeRef::fromAttrs(
+            nix::fetchSettings,
+            nix::fetchers::jsonToAttrs(
+                nlohmann::json::parse(args.lockedFlakeAttrs)));
+    }
 
     nix::InstallableFlake flake{{},       state,      std::move(flakeRef),
                                 fragment, outputSpec, {},
@@ -293,7 +304,7 @@ auto initializeRootValue(const nix::ref<nix::EvalState> &state,
                          nix::Bindings &autoArgs, MyArgs &args)
     -> nix::Value * {
     nix::Value *vEvaluated =
-        args.flake ? evaluateFlake(state, args.releaseExpr, args.lockFlags)
+        args.flake ? evaluateFlake(state, args)
                    : releaseExprTopLevelValue(*state, autoArgs, args);
 
     if (args.selectExpr.empty()) {
@@ -399,10 +410,35 @@ auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
 
 } // namespace
 
+auto prefetchFlake(MyArgs &args) -> std::optional<std::string> {
+    auto evalStore = nix_eval_jobs::openStore(args.evalStoreUrl);
+    auto state = nix::make_ref<nix::EvalState>(
+        args.lookupPath, evalStore, nix::fetchSettings, nix::evalSettings);
+    auto [flakeRef, fragment, outputSpec] =
+        nix::parseFlakeRefWithFragmentAndExtendedOutputsSpec(
+            nix::fetchSettings, args.releaseExpr,
+            nix::absPath(std::filesystem::path(".")));
+    auto locked = nix::flake::lockFlake(nix::flakeSettings, *state, flakeRef,
+                                        args.lockFlags);
+
+    auto lockedRef = locked.flake.lockedRef;
+    if (!lockedRef.input.isFinal() || !lockedRef.input.getNarHash()) {
+        return std::nullopt;
+    }
+    lockedRef.input =
+        lockedRef.input.fetchToStore(nix::fetchSettings, *state->store).second;
+    return nix::fetchers::attrsToJSON(lockedRef.toAttrs()).dump();
+}
+
 void worker(
     MyArgs &args,
     nix::AutoCloseFD &toParent, // NOLINT(bugprone-easily-swappable-parameters)
     nix::AutoCloseFD &fromParent) {
+
+    LineReader fromReader(fromParent.release());
+
+    auto config = nlohmann::json::parse(fromReader.readLine());
+    args.lockedFlakeAttrs = config.value("lockedFlake", "");
 
     auto evalStore = nix_eval_jobs::openStore(args.evalStoreUrl);
     auto state = nix::make_ref<nix::EvalState>(
@@ -410,8 +446,6 @@ void worker(
     nix::Bindings &autoArgs = *args.getAutoArgs(*state);
 
     nix::Value *vRoot = initializeRootValue(state, autoArgs, args);
-
-    LineReader fromReader(fromParent.release());
 
     while (processJobRequest(*state, fromReader, toParent, autoArgs, vRoot,
                              args)) {

--- a/src/worker.hh
+++ b/src/worker.hh
@@ -24,5 +24,8 @@ constexpr std::string_view MSG_DO = "do ";
 constexpr int WORKER_OUT_FD = 3; // worker -> collector
 constexpr int WORKER_IN_FD = 4;  // collector -> worker
 
+/* Lock the flake once before workers spawn. */
+auto prefetchFlake(MyArgs &args) -> std::optional<std::string>;
+
 void worker(MyArgs &args, nix::AutoCloseFD &toParent,
             nix::AutoCloseFD &fromParent);

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -854,3 +854,48 @@ def test_fetchers_survive_worker_restart(tmp_path: Path) -> None:
 
     results = [json.loads(line) for line in res.stdout.splitlines() if line]
     assert len(results) == 2
+
+
+def test_workers_do_not_race_flake_fetch(tmp_path: Path) -> None:
+    """Workers fetching the same flake input concurrently spam "waiting
+    for another Nix process to finish fetching input" (issue #432)."""
+    env = _hermetic_nix_env(tmp_path)
+    repo = tmp_path / "flake"
+    repo.mkdir()
+    jobs = "\n".join(
+        f"""
+        job-{i} = derivation {{
+          name = "race-{i}";
+          system = "x86_64-linux";
+          builder = "/bin/sh";
+          args = [ "-c" "echo {i} > $out" ]; }};"""
+        for i in range(8)
+    )
+    repo.joinpath("flake.nix").write_text(f"{{ outputs = _: {{ hydraJobs = {{ {jobs} }}; }}; }}")
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+    subprocess.run(["git", "add", "flake.nix"], cwd=repo, check=True, env=env)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init"],
+        cwd=repo,
+        check=True,
+        env=env,
+    )
+
+    res = subprocess.run(
+        [
+            str(BIN),
+            "--gc-roots-dir",
+            str(tmp_path / "gc"),
+            "--workers",
+            "8",
+            *COMMON_FLAGS,
+            "--flake",
+            f"git+file://{repo}#hydraJobs",
+        ],
+        env=env,
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    assert len(res.stdout.splitlines()) == 8
+    assert "waiting for another Nix process" not in res.stderr, res.stderr


### PR DESCRIPTION
Workers racing to fetch the same top-level flake spam "waiting for another Nix process to finish fetching input" once per worker. The fetch lock-free fast path requires a final input with a narHash.

Lock the flake once in the collector and send the locked flakeref attrs to each worker as the first pipe message. Workers then skip the fetch and its lock entirely.

Fixes #432