### PR TITLE
release 2.35.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  revision = "0";
+  revision = "1";
 in
 stdenv.mkDerivation {
   pname = "nix-eval-jobs";


### PR DESCRIPTION
## What's Changed
* cache-status-resolver: query substituters through the store by @Mic92 in https://github.com/NixOS/nix-eval-jobs/pull/434
* fix: Forward log-format to workers by @pkpbynum in https://github.com/NixOS/nix-eval-jobs/pull/431
* collector: don't write exit to a worker that announced restart by @Mic92 in https://github.com/NixOS/nix-eval-jobs/pull/435
* workers: spawn via fork+exec instead of plain fork by @Mic92 in https://github.com/NixOS/nix-eval-jobs/pull/436
* Fix stackoverflow handling and adopt crash-handler similar to nix by @Mic92 in https://github.com/NixOS/nix-eval-jobs/pull/437
* collector: pre-lock the flake and pass it to the workers by @Mic92 in https://github.com/NixOS/nix-eval-jobs/pull/438

## New Contributors
* @pkpbynum made their first contribution in https://github.com/NixOS/nix-eval-jobs/pull/431

**Full Changelog**: https://github.com/NixOS/nix-eval-jobs/compare/v2.35.0...v2.35.1
