### PR TITLE
cache-status-resolver: query validity against the build store

### DIFF
--- a/src/cache-status-resolver.cc
+++ b/src/cache-status-resolver.cc
@@ -35,8 +35,11 @@ void sortPaths(std::vector<nix::StorePath> &paths) {
 
 } // namespace
 
-CacheStatusResolver::CacheStatusResolver(nix::ref<nix::Store> store, Sink sink)
-    : store(std::move(store)), sink(std::move(sink)) {
+CacheStatusResolver::CacheStatusResolver(nix::ref<nix::Store> evalStore,
+                                         nix::ref<nix::Store> buildStore,
+                                         Sink sink)
+    : evalStore(std::move(evalStore)), buildStore(std::move(buildStore)),
+      sink(std::move(sink)) {
     worker = std::thread([this]() -> void { run(); });
 }
 
@@ -138,7 +141,7 @@ void CacheStatusResolver::run() {
 void CacheStatusResolver::resolveWanted() {
     if (!wantedValid.empty()) {
         const auto batch = std::exchange(wantedValid, {});
-        const auto valid = store->queryValidPaths(batch);
+        const auto valid = buildStore->queryValidPaths(batch);
         for (const auto &path : batch) {
             validCache.emplace(path, valid.contains(path));
         }
@@ -152,7 +155,7 @@ void CacheStatusResolver::resolveWanted() {
     }
     nix::SubstitutablePathInfos infos;
     try {
-        store->querySubstitutablePathInfos(batch, infos);
+        buildStore->querySubstitutablePathInfos(batch, infos);
     } catch (nix::Error &) { // NOLINT(bugprone-empty-catch)
         /* Unreachable substituters count as misses. */
     }
@@ -195,7 +198,7 @@ auto CacheStatusResolver::readDerivation(const nix::StorePath &drvPath)
     if (auto cached = drvCache.find(drvPath); cached != drvCache.end()) {
         return cached->second;
     }
-    return drvCache.emplace(drvPath, store->readDerivation(drvPath))
+    return drvCache.emplace(drvPath, evalStore->readDerivation(drvPath))
         .first->second;
 }
 
@@ -207,7 +210,7 @@ auto CacheStatusResolver::missingOutputs(const nix::Derivation &derivation,
     -> MissingOutputs {
     MissingOutputs result;
     for (const auto &[outputName, outputPathOpt] :
-         derivation.outputsAndOptPaths(*store)) {
+         derivation.outputsAndOptPaths(*evalStore)) {
         if (!wantedOutputs.empty() && !wantedOutputs.contains(outputName)) {
             continue;
         }

--- a/src/cache-status-resolver.hh
+++ b/src/cache-status-resolver.hh
@@ -30,7 +30,11 @@ class CacheStatusResolver {
      */
     using Sink = std::function<void(Response)>;
 
-    CacheStatusResolver(nix::ref<nix::Store> store, Sink sink);
+    /* Derivations are read from the eval store. Validity and
+     * substitutability are resolved against the build store, the eval
+     * store never holds outputs. */
+    CacheStatusResolver(nix::ref<nix::Store> evalStore,
+                        nix::ref<nix::Store> buildStore, Sink sink);
     ~CacheStatusResolver();
 
     CacheStatusResolver(const CacheStatusResolver &) = delete;
@@ -76,7 +80,8 @@ class CacheStatusResolver {
         -> const nix::Derivation &;
     void resolveWanted();
 
-    nix::ref<nix::Store> store;
+    nix::ref<nix::Store> evalStore;
+    nix::ref<nix::Store> buildStore;
     Sink sink;
 
     std::mutex mutex;

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -483,6 +483,7 @@ auto makeCacheStatusResolver(const MyArgs &args, nix::Sync<State> &state_)
     }
     return std::optional<CacheStatusResolver>(
         std::in_place, nix_eval_jobs::openStore(args.evalStoreUrl),
+        nix_eval_jobs::openStore(),
         [&state_](const Response &response) -> void {
             nlohmann::json jsonResponse = response;
             auto dumped = jsonResponse.dump();


### PR DESCRIPTION

The resolver used the eval store for everything. Derivations do live
there, but outputs never do, so with a separate --eval-store the
local cache status was never reported. Read derivations from the eval
store and resolve validity and substitutability against the build
store. With the default store both are the same daemon.
