### PR TITLE
constituents: work with any eval store

### DIFF
--- a/src/constituents.cc
+++ b/src/constituents.cc
@@ -110,7 +110,7 @@ namespace {
 void addConstituents(nlohmann::json &job, nix::Derivation &drv,
                      const std::set<std::string> &dependencies,
                      const std::map<std::string, nlohmann::json> &jobs,
-                     const nix::ref<nix::LocalFSStore> &store) {
+                     const nix::ref<nix::Store> &store) {
     for (const auto &childJobName : dependencies) {
         auto childDrvPath = store->parseStorePath(
             std::string(jobs.find(childJobName)->second["drvPath"]));
@@ -123,7 +123,7 @@ void addConstituents(nlohmann::json &job, nix::Derivation &drv,
 
 void rewriteAndRegisterDrv(nlohmann::json &job, nix::Derivation &drv,
                            const nix::StorePath &drvPath,
-                           const nix::ref<nix::LocalFSStore> &store,
+                           const nix::ref<nix::Store> &store,
                            const std::filesystem::path &gcRootsDir) {
     // Reset outputs so fillInOutputPaths recomputes them
     // with the updated inputDrvs (constituents).
@@ -143,11 +143,14 @@ void rewriteAndRegisterDrv(nlohmann::json &job, nix::Derivation &drv,
 
     auto newDrvPathS = store->printStorePath(newDrvPath);
 
-    if (!gcRootsDir.empty()) {
+    /* Only file system stores support gc roots. Stores with their own
+       retention (e.g. an eval store plugin) keep the drv alive themselves. */
+    auto localStore = store.dynamic_pointer_cast<nix::LocalFSStore>();
+    if (!gcRootsDir.empty() && localStore) {
         const auto root =
             gcRootsDir / std::string(nix::baseNameOf(newDrvPathS));
         if (!nix::pathExists(root)) {
-            store->addPermRoot(newDrvPath, root);
+            localStore->addPermRoot(newDrvPath, root);
         }
     }
 
@@ -236,7 +239,7 @@ auto resolveNamedConstituents(const std::map<std::string, nlohmann::json> &jobs)
 
 void rewriteAggregates(std::map<std::string, nlohmann::json> &jobs,
                        const std::vector<AggregateJob> &aggregateJobs,
-                       const nix::ref<nix::LocalFSStore> &store,
+                       const nix::ref<nix::Store> &store,
                        const std::filesystem::path &gcRootsDir) {
     for (const auto &aggregateJob : aggregateJobs) {
         auto &job = jobs.find(aggregateJob.name)->second;

--- a/src/constituents.hh
+++ b/src/constituents.hh
@@ -47,5 +47,5 @@ auto resolveNamedConstituents(const std::map<std::string, nlohmann::json> &jobs)
 
 void rewriteAggregates(std::map<std::string, nlohmann::json> &jobs,
                        const std::vector<AggregateJob> &aggregateJobs,
-                       const nix::ref<nix::LocalFSStore> &store,
+                       const nix::ref<nix::Store> &store,
                        const std::filesystem::path &gcRootsDir);

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -101,20 +101,11 @@ void handleConstituents(std::map<std::string, nlohmann::json> &jobs,
                         const MyArgs &args) {
 
     auto store = nix_eval_jobs::openStore(args.evalStoreUrl);
-    auto localStore = store.dynamic_pointer_cast<nix::LocalFSStore>();
-
-    if (!localStore) {
-        nix::warn("constituents feature requires a local store, skipping "
-                  "aggregate rewriting");
-        return;
-    }
-
-    auto localStoreRef = nix::ref<nix::LocalFSStore>(localStore);
 
     std::visit(
         nix::overloaded{
             [&](const std::vector<AggregateJob> &namedConstituents) -> void {
-                rewriteAggregates(jobs, namedConstituents, localStoreRef,
+                rewriteAggregates(jobs, namedConstituents, store,
                                   args.gcRootsDir);
             },
             [&](const DependencyCycle &cycle) -> void {


### PR DESCRIPTION

Aggregate rewriting only needs the plain Store API. The LocalFSStore
requirement came from a single addPermRoot call, which is now guarded
instead of disabling the feature. Stores with their own retention
keep the rewritten drv alive themselves.
