### PR TITLE
Small readability cleanups (eval-args, joinAttrPath, worker, RSS helper)

### DIFF
--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -21,14 +21,17 @@
 #include "eval-args.hh"
 #include "output-stream-lock.hh"
 
+// nix::Args::Flag has many default-valued fields we intentionally omit.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
+#endif
+
 MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
     addFlag({
         .longName = "help",
-        .aliases = {},
-        .shortName = 0,
         .description = "show usage information",
-        .category = "",
-        .labels = {},
         .handler = {[&]() -> void {
             getCoutLock().lock() << "USAGE: nix-eval-jobs [options] expr\n\n";
             for (const auto &[name, flag] : longFlags) {
@@ -43,197 +46,114 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
 
             ::exit(0); // NOLINT(concurrency-mt-unsafe)
         }},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "impure",
-        .aliases = {},
-        .shortName = 0,
         .description = "allow impure expressions",
-        .category = "",
-        .labels = {},
         .handler = {&impure, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "force-recurse",
-        .aliases = {},
-        .shortName = 0,
         .description = "force recursion (don't respect recurseIntoAttrs)",
-        .category = "",
-        .labels = {},
         .handler = {&forceRecurse, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "gc-roots-dir",
-        .aliases = {},
-        .shortName = 0,
         .description = "garbage collector roots directory",
-        .category = "",
         .labels = {"path"},
         .handler = {&gcRootsDir},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "workers",
-        .aliases = {},
-        .shortName = 0,
         .description = "number of evaluate workers",
-        .category = "",
         .labels = {"workers"},
         .handler = {[this](const std::string &str) -> void {
             nrWorkers = std::stoi(str);
         }},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "max-memory-size",
-        .aliases = {},
-        .shortName = 0,
         .description = "maximum evaluation memory size in megabyte "
                        "(4GiB per worker by default)",
-        .category = "",
         .labels = {"size"},
         .handler = {[this](const std::string &str) -> void {
             maxMemorySize = std::stoi(str);
         }},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "flake",
-        .aliases = {},
-        .shortName = 0,
         .description = "build a flake",
-        .category = "",
-        .labels = {},
         .handler = {&flake, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "meta",
-        .aliases = {},
-        .shortName = 0,
         .description = "include derivation meta field in output",
-        .category = "",
-        .labels = {},
         .handler = {&meta, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "constituents",
-        .aliases = {},
-        .shortName = 0,
         .description =
             "whether to evaluate constituents for Hydra's aggregate feature",
-        .category = "",
-        .labels = {},
         .handler = {&constituents, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "check-cache-status",
-        .aliases = {},
-        .shortName = 0,
         .description = "Check if the derivations are present locally or in "
                        "any configured substituters (i.e. binary cache). The "
                        "information will be exposed in the `cacheStatus` field "
                        "of the JSON output.",
-        .category = "",
-        .labels = {},
         .handler = {&checkCacheStatus, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "show-input-drvs",
-        .aliases = {},
-        .shortName = 0,
         .description =
             "Show input derivations in the output for each derivation. "
             "This is useful to get direct dependencies of a derivation.",
-        .category = "",
-        .labels = {},
         .handler = {&showInputDrvs, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "show-trace",
-        .aliases = {},
-        .shortName = 0,
         .description = "print out a stack trace in case of evaluation errors",
-        .category = "",
-        .labels = {},
         .handler = {&showTrace, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "no-instantiate",
-        .aliases = {},
-        .shortName = 0,
         .description =
             "don't instantiate (write) derivations, only evaluate (faster)",
-        .category = "",
-        .labels = {},
         .handler = {&noInstantiate, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "expr",
-        .aliases = {},
         .shortName = 'E',
         .description = "treat the argument as a Nix expression",
-        .category = "",
-        .labels = {},
         .handler = {&fromArgs, true},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "apply",
-        .aliases = {},
-        .shortName = 0,
         .description =
             "Apply provided Nix function to each derivation. "
             "The result of this function will be serialized as a JSON value "
             "and stored inside `\"extraValue\"` key of the json line output.",
-        .category = "",
         .labels = {"expr"},
         .handler = {&applyExpr},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "select",
-        .aliases = {},
-        .shortName = 0,
         .description =
             "Apply provided Nix function to transform the evaluation root. "
             "This is applied before any attribute traversal begins. "
@@ -245,18 +165,13 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
             "--select 'flake: flake.outputs.packages' "
             "--select 'flake: flake.inputs.nixpkgs' "
             "--select 'outputs: outputs.packages.x86_64-linux'",
-        .category = "",
         .labels = {"expr"},
         .handler = {&selectExpr},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     // usually in MixFlakeOptions
     addFlag({
         .longName = "override-input",
-        .aliases = {},
-        .shortName = 0,
         .description =
             "Override a specific flake input (e.g. `dwarffs/nixpkgs`).",
         .category = category,
@@ -276,14 +191,10 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
                                    nix::absPath(std::filesystem::path(".")),
                                    true));
         }},
-        .completer = nullptr,
-        .experimentalFeature = std::nullopt,
     });
 
     addFlag({
         .longName = "reference-lock-file",
-        .aliases = {},
-        .shortName = 0,
         .description = "Read the given lock file instead of `flake.lock` "
                        "within the top-level flake.",
         .category = category,
@@ -295,13 +206,11 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
             };
         }},
         .completer = completePath,
-        .experimentalFeature = std::nullopt,
     });
 
     const std::string internalCategory = "Internal flags";
     addFlag({
         .longName = "worker",
-        .aliases = {},
         .description = "run as an evaluation worker process",
         .category = internalCategory,
         .handler = {&runAsWorker, true},
@@ -310,6 +219,8 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
 
     expectArg("expr", &releaseExpr);
 }
+
+#pragma GCC diagnostic pop
 
 void MyArgs::parseArgs(char **argv, int argc) {
     parseCmdline(nix::argvToStrings(argc, argv), false);

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,7 +8,8 @@ common_src = [
   'worker.cc',
   'output-stream-lock.cc',
   'cache-status-resolver.cc',
-  'daemon-settings.cc'
+  'daemon-settings.cc',
+  'rss.cc',
 ]
 
 common_deps = [

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -337,17 +337,6 @@ void handleBrokenWorkerPipe(Proc &proc, std::string_view msg) {
     }
 }
 
-auto joinAttrPath(const nlohmann::json &attrPath) -> std::string {
-    std::string joined;
-    for (const auto &element : attrPath) {
-        if (!joined.empty()) {
-            joined += '.';
-        }
-        joined += element.get<std::string>();
-    }
-    return joined;
-}
-
 namespace {
 auto checkWorkerStatus(LineReader *fromReader, Proc *proc) -> std::string_view {
     auto line = fromReader->readLine();

--- a/src/response.cc
+++ b/src/response.cc
@@ -12,6 +12,18 @@
 #include "response.hh"
 #include "drv.hh"
 
+auto joinAttrPath(const nlohmann::json &attrPath) -> std::string {
+    std::string joined;
+    for (const auto &element : attrPath) {
+        auto part = element.get<std::string>();
+        if (part.find('.') != std::string::npos) {
+            part = "\"" + part + "\"";
+        }
+        joined += joined.empty() ? part : "." + part;
+    }
+    return joined;
+}
+
 namespace nlohmann {
 
 using nix::get;

--- a/src/response.hh
+++ b/src/response.hh
@@ -50,4 +50,8 @@ struct Response {
     bool operator==(const Response &) const = default;
 };
 
+/* Dot-joined attribute path as used for Response::attr. Components that
+   contain dots are quoted. */
+auto joinAttrPath(const nlohmann::json &attrPath) -> std::string;
+
 JSON_IMPL(Response)

--- a/src/rss.cc
+++ b/src/rss.cc
@@ -1,0 +1,83 @@
+#include "rss.hh"
+
+#include <cstddef>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#include <cstdio>
+#include <string>
+#elif defined(__APPLE__)
+#include <libproc.h>
+#include <sys/resource.h>
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#endif
+
+namespace {
+constexpr size_t MIB = 1024 * 1024;
+
+[[maybe_unused]] auto pagesToMiB(size_t pages) -> size_t {
+    static const auto pageSize = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    return pages * pageSize / MIB;
+}
+} // namespace
+
+auto residentMemoryMiB(pid_t pid) -> size_t {
+#ifdef __linux__
+    const std::string path = "/proc/" + std::to_string(pid) + "/statm";
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    FILE *file = std::fopen(path.c_str(), "re");
+    if (file == nullptr) {
+        return 0;
+    }
+    unsigned long size = 0;
+    unsigned long resident = 0;
+    // NOLINTNEXTLINE(cert-err34-c)
+    const int n = std::fscanf(file, "%lu %lu", &size, &resident);
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    std::fclose(file);
+    return n == 2 ? pagesToMiB(resident) : 0;
+#elif defined(__APPLE__)
+    struct rusage_info_v4 info = {};
+    if (proc_pid_rusage(
+            pid, RUSAGE_INFO_V4,
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            reinterpret_cast<rusage_info_t *>(&info)) != 0) {
+        return 0;
+    }
+    return info.ri_phys_footprint / MIB;
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+    struct kinfo_proc info = {};
+    size_t len = sizeof(info);
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+    if (sysctl(mib, 4, &info, &len, nullptr, 0) != 0 || len == 0) {
+        return 0;
+    }
+#ifdef __DragonFly__
+    return pagesToMiB(info.kp_vm_rssize);
+#else
+    return pagesToMiB(info.ki_rssize);
+#endif
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
+#ifdef __NetBSD__
+    struct kinfo_proc2 info = {};
+    int mib[6] = {CTL_KERN, KERN_PROC2, KERN_PROC_PID, pid, sizeof(info), 1};
+#else
+    struct kinfo_proc info = {};
+    int mib[6] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid, sizeof(info), 1};
+#endif
+    size_t len = sizeof(info);
+    if (sysctl(mib, 6, &info, &len, nullptr, 0) != 0 || len == 0) {
+        return 0;
+    }
+    return pagesToMiB(info.p_vm_rssize);
+#else
+#error "residentMemoryMiB() is not implemented for this platform"
+#endif
+}

--- a/src/rss.hh
+++ b/src/rss.hh
@@ -1,0 +1,8 @@
+#pragma once
+///@file
+
+#include <cstddef>
+#include <sys/types.h>
+
+/* Current resident memory of a process in MiB, 0 if it is gone. */
+auto residentMemoryMiB(pid_t pid) -> size_t;

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -119,80 +119,67 @@ auto evaluateFlake(const nix::ref<nix::EvalState> &state, const MyArgs &args)
     return flake.toValue(*state).first;
 }
 
+auto forceBoolAttr(nix::EvalState &state, nix::Value *value,
+                   std::string_view name) -> bool {
+    const auto *attr = value->attrs()->get(state.symbols.create(name));
+    return attr != nullptr &&
+           state.forceBool(
+               *attr->value, attr->pos,
+               nix::fmt("while evaluating the `%s` attribute", name));
+}
+
+/* Derivation constituents: store paths from the string context of
+   `constituents`. */
+auto drvConstituents(nix::EvalState &state, const nix::Attr &attr)
+    -> std::vector<std::string> {
+    nix::NixStringContext context;
+    state.coerceToString(attr.pos, *attr.value, context,
+                         "while evaluating the `constituents` attribute", true,
+                         false);
+    std::vector<std::string> drvs;
+    for (const auto &ctx : context) {
+        if (const auto *built =
+                std::get_if<nix::NixStringContextElem::Built>(&ctx.raw)) {
+            drvs.push_back(built->drvPath->to_string(*state.store));
+        }
+    }
+    return drvs;
+}
+
+/* Named constituents: plain strings in the `constituents` list, resolved
+   to jobs by the collector. */
+auto namedConstituents(nix::EvalState &state, const nix::Attr &attr)
+    -> std::vector<std::string> {
+    state.forceList(*attr.value, attr.pos,
+                    "while evaluating the `constituents` attribute");
+    std::vector<std::string> names;
+    for (const auto &val : attr.value->listView()) {
+        state.forceValue(*val, nix::noPos);
+        if (val->type() == nix::nString) {
+            names.emplace_back(val->c_str());
+        }
+    }
+    return names;
+}
+
 auto extractConstituents(nix::EvalState &state, nix::Value *value,
                          const MyArgs &args) -> Constituents {
-    if (!args.constituents) {
+    if (!args.constituents || !forceBoolAttr(state, value, "_hydraAggregate")) {
         return {};
     }
-
-    std::vector<std::string> constituents;
-    std::vector<std::string> namedConstituents;
-    bool globConstituents = false;
-
-    const auto *aggregateAttr =
-        value->attrs()->get(state.symbols.create("_hydraAggregate"));
-
-    if (aggregateAttr != nullptr &&
-        state.forceBool(*aggregateAttr->value, aggregateAttr->pos,
-                        "while evaluating the `_hydraAggregate` attribute")) {
-
-        const auto *constituentsAttr =
-            value->attrs()->get(state.symbols.create("constituents"));
-
-        if (constituentsAttr == nullptr) {
-            state
-                .error<nix::EvalError>(
-                    "derivation must have a 'constituents' attribute")
-                .debugThrow();
-        }
-
-        // Extract constituent paths from context
-        nix::NixStringContext context;
-        state.coerceToString(
-            constituentsAttr->pos, *constituentsAttr->value, context,
-            "while evaluating the `constituents` attribute", true, false);
-
-        for (const auto &ctx : context) {
-            std::visit(
-                nix::overloaded{
-                    [&](const nix::NixStringContextElem::Built &built) -> void {
-                        constituents.push_back(
-                            built.drvPath->to_string(*state.store));
-                    },
-                    [&](const nix::NixStringContextElem::Opaque &opaque
-                        [[maybe_unused]]) -> void {},
-                    [&](const nix::NixStringContextElem::DrvDeep &drvDeep
-                        [[maybe_unused]]) -> void {},
-                },
-                ctx.raw);
-        }
-
-        // Extract named constituents
-        state.forceList(*constituentsAttr->value, constituentsAttr->pos,
-                        "while evaluating the `constituents` attribute");
-        auto constituentsList = constituentsAttr->value->listView();
-
-        for (const auto &val : constituentsList) {
-            state.forceValue(*val, nix::noPos);
-            if (val->type() == nix::nString) {
-                namedConstituents.emplace_back(val->c_str());
-            }
-        }
-
-        // Check for glob constituents
-        const auto *glob =
-            value->attrs()->get(state.symbols.create("_hydraGlobConstituents"));
-        globConstituents =
-            glob != nullptr &&
-            state.forceBool(
-                *glob->value, glob->pos,
-                "while evaluating the `_hydraGlobConstituents` attribute");
+    const auto *attr =
+        value->attrs()->get(state.symbols.create("constituents"));
+    if (attr == nullptr) {
+        state
+            .error<nix::EvalError>(
+                "derivation must have a 'constituents' attribute")
+            .debugThrow();
     }
-
     return Constituents{
-        .constituents = std::move(constituents),
-        .namedConstituents = std::move(namedConstituents),
-        .globConstituents = globConstituents,
+        .constituents = drvConstituents(state, *attr),
+        .namedConstituents = namedConstituents(state, *attr),
+        .globConstituents =
+            forceBoolAttr(state, value, "_hydraGlobConstituents"),
     };
 }
 
@@ -232,7 +219,6 @@ auto registerGCRoot(nix::EvalState &state, const Drv &drv, const MyArgs &args)
         if (localStore) {
             localStore->addPermRoot(drv.drvPath, root);
         }
-        // If not a local store, we can't create GC roots
     }
 }
 
@@ -268,20 +254,15 @@ auto processDerivation(nix::EvalState &state, nix::Value *value,
         return Response::Attrs{std::move(attrs)};
     }
 
-    // Extract constituents if enabled
     auto constituents = extractConstituents(state, value, args);
 
-    // Apply expression if provided
     std::optional<nlohmann::json> extraValue;
     if (!args.applyExpr.empty()) {
         extraValue = applyExprToValue(state, value, args.applyExpr);
     }
 
-    // Create derivation info
     auto drv = Drv::fromPackageInfo(attrPathS, state, *packageInfo, args,
                                     std::move(constituents));
-
-    // Register GC root
     registerGCRoot(state, drv, args);
 
     return Response::Job{std::move(drv), std::move(extraValue)};
@@ -298,7 +279,6 @@ auto initializeRootValue(const nix::ref<nix::EvalState> &state,
         return vEvaluated;
     }
 
-    // Apply the provided select function
     auto *selectExpr =
         state->parseExprFromString(args.selectExpr, state->rootPath("."));
 
@@ -327,72 +307,68 @@ auto shouldRestart(const MyArgs &args) -> bool {
     return maxrss > args.maxMemorySize * KB_TO_BYTES;
 }
 
-auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
-                       nix::AutoCloseFD &toParent, nix::Bindings &autoArgs,
-                       nix::Value *vRoot, MyArgs &args) -> bool {
-    /* Wait for the collector to send us a job name. */
+struct Evaluator {
+    nix::EvalState &state;
+    nix::Bindings &autoArgs;
+    nix::Value *vRoot;
+    MyArgs &args;
+
+    auto evaluate(const nlohmann::json &path) -> Response::Payload {
+        auto attrPathS = joinAttrPath(path);
+        try {
+            auto *vTmp =
+                nix::findAlongAttrPath(state, attrPathS, autoArgs, *vRoot)
+                    .first;
+            auto *value = state.allocValue();
+            state.autoCallFunction(autoArgs, *vTmp, *value);
+            if (value->type() != nix::nAttrs) {
+                return Response::Attrs{{}}; // not buildable, ignore
+            }
+            return processDerivation(state, value, attrPathS, path, args);
+        } catch (nix::StackOverflowError &e) {
+            /* Not an EvalError. Fatal aborts the whole evaluation. */
+            return Response::Error{
+                .error = nix::filterANSIEscapes(showError(e.info()), true),
+                .fatal = true,
+            };
+        } catch (nix::EvalError &e) {
+            return Response::Error{
+                nix::filterANSIEscapes(showError(e.info()), true)};
+        } catch (const std::exception &e) {
+            std::cerr << e.what() << '\n';
+            return Response::Error{nix::filterANSIEscapes(e.what(), true)};
+        }
+    }
+};
+
+/* One request/response round with the collector. False once the worker
+   should exit (collector gone, told to exit, or memory share used up). */
+auto processJobRequest(Evaluator &evaluator, LineReader &fromReader,
+                       nix::AutoCloseFD &toParent) -> bool {
     if (tryWriteLine(toParent.get(), std::string(MSG_NEXT)) < 0) {
-        return false; // main process died
+        return false;
     }
 
     auto line = fromReader.readLine();
     if (line == MSG_EXIT) {
         return false;
     }
-
     if (!nix::hasPrefix(line, MSG_DO)) {
         std::cerr << "worker error: received invalid command '" << line
                   << "'\n";
         abort();
     }
-
     auto path = nlohmann::json::parse(line.substr(MSG_DO.size()));
-    auto attrPathS = joinAttrPath(path);
 
-    /* Evaluate it and send info back to the collector. */
-    Response::Payload payload = [&]() -> Response::Payload {
-        try {
-            auto *vTmp =
-                nix::findAlongAttrPath(state, attrPathS, autoArgs, *vRoot)
-                    .first;
-
-            auto *value = state.allocValue();
-            state.autoCallFunction(autoArgs, *vTmp, *value);
-
-            if (value->type() == nix::nAttrs) {
-                return processDerivation(state, value, attrPathS, path, args);
-            }
-            // We ignore everything that cannot be built
-            return Response::Attrs{{}};
-        } catch (nix::StackOverflowError &e) {
-            /* Not an EvalError. Fatal aborts the whole evaluation. */
-            auto msg = showError(e.info());
-            return Response::Error{
-                .error = nix::filterANSIEscapes(msg, true),
-                .fatal = true,
-            };
-        } catch (nix::EvalError &e) {
-            auto msg = showError(e.info());
-            return Response::Error{nix::filterANSIEscapes(msg, true)};
-        } catch (const std::exception &e) {
-            const auto *msg = e.what();
-            std::cerr << msg << '\n';
-            return Response::Error{nix::filterANSIEscapes(msg, true)};
-        }
-    }();
-
-    Response const response{
-        .attr = attrPathS,
+    const Response response{
+        .attr = joinAttrPath(path),
         .attrPath = path.get<std::vector<std::string>>(),
-        .payload = std::move(payload),
+        .payload = evaluator.evaluate(path),
     };
-    nlohmann::json const reply = response;
-    if (tryWriteLine(toParent.get(), reply.dump()) < 0) {
-        return false; // main process died
+    if (tryWriteLine(toParent.get(), nlohmann::json(response).dump()) < 0) {
+        return false;
     }
-
-    /* Check if we should restart due to memory usage */
-    return !shouldRestart(args);
+    return !shouldRestart(evaluator.args);
 }
 
 } // namespace
@@ -432,14 +408,15 @@ void worker(
         args.lookupPath, evalStore, nix::fetchSettings, nix::evalSettings);
     nix::Bindings &autoArgs = *args.getAutoArgs(*state);
 
-    nix::Value *vRoot = initializeRootValue(state, autoArgs, args);
+    Evaluator evaluator{
+        .state = *state,
+        .autoArgs = autoArgs,
+        .vRoot = initializeRootValue(state, autoArgs, args),
+        .args = args,
+    };
 
-    while (processJobRequest(*state, fromReader, toParent, autoArgs, vRoot,
-                             args)) {
-        // Continue processing jobs until we need to exit
+    while (processJobRequest(evaluator, fromReader, toParent)) {
     }
 
-    if (tryWriteLine(toParent.get(), std::string(MSG_RESTART)) < 0) {
-        return; // main process died
-    };
+    (void)tryWriteLine(toParent.get(), std::string(MSG_RESTART));
 }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -37,7 +37,6 @@
 #include <nix/expr/value.hh>
 #include <nix/expr/value/context.hh>
 #include <nlohmann/json_fwd.hpp>
-#include <numeric>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -118,18 +117,6 @@ auto evaluateFlake(const nix::ref<nix::EvalState> &state, const MyArgs &args)
     }
     // Fragment specified, use normal evaluation
     return flake.toValue(*state).first;
-}
-
-auto attrPathJoin(nlohmann::json input) -> std::string {
-    return std::accumulate(
-        input.begin(), input.end(), std::string(),
-        [](const std::string &acc, std::string str) -> std::basic_string<char> {
-            // Escape token if containing dots
-            if (str.find('.') != std::string::npos) {
-                str = "\"" + str + "\"";
-            }
-            return acc.empty() ? str : acc + "." + str;
-        });
 }
 
 auto extractConstituents(nix::EvalState &state, nix::Value *value,
@@ -360,7 +347,7 @@ auto processJobRequest(nix::EvalState &state, LineReader &fromReader,
     }
 
     auto path = nlohmann::json::parse(line.substr(MSG_DO.size()));
-    auto attrPathS = attrPathJoin(path);
+    auto attrPathS = joinAttrPath(path);
 
     /* Evaluate it and send info back to the collector. */
     Response::Payload payload = [&]() -> Response::Payload {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1,5 +1,4 @@
 // doesn't exist on macOS
-// IWYU pragma: no_include <bits/types/struct_rusage.h>
 
 #include <nix/expr/eval-error.hh>
 #include <nix/util/pos-idx.hh>
@@ -9,7 +8,7 @@
 #include <nix/store/globals.hh>
 #include <nix/cmd/installable-flake.hh>
 #include <nix/expr/value-to-json.hh>
-#include <sys/resource.h>
+#include <unistd.h>
 #include <nlohmann/json.hpp>
 #include <cstdio>
 #include <iostream>
@@ -51,6 +50,7 @@
 #include "buffered-io.hh"
 #include "eval-args.hh"
 #include "store.hh"
+#include "rss.hh"
 
 namespace nix {
 struct Expr;
@@ -295,16 +295,7 @@ auto initializeRootValue(const nix::ref<nix::EvalState> &state,
 }
 
 auto shouldRestart(const MyArgs &args) -> bool {
-    struct rusage resourceUsage = {}; // NOLINT(misc-include-cleaner)
-    getrusage(RUSAGE_SELF, &resourceUsage);
-    size_t maxrss =
-        resourceUsage
-            .ru_maxrss; // NOLINT(cppcoreguidelines-pro-type-union-access)
-    static constexpr size_t KB_TO_BYTES = 1024;
-#ifdef __APPLE__
-    maxrss /= KB_TO_BYTES; // ru_maxrss is bytes on macOS instead of KiB
-#endif
-    return maxrss > args.maxMemorySize * KB_TO_BYTES;
+    return residentMemoryMiB(getpid()) > args.maxMemorySize;
 }
 
 struct Evaluator {


### PR DESCRIPTION
Independent cleanups, split out of the memory-budget work:

- eval-args: drop empty designated initializers
- Unify the two attribute path join helpers (the collector copy did not quote dotted components)
- worker: separate protocol handling from evaluation, split extractConstituents
- Add residentMemoryMiB() and use current RSS instead of lifetime peak for worker restarts