### PR TITLE
Replace per-worker collector threads with a poll() loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This project evaluates nix attribute sets in parallel with streamable json
 output. This is useful for time and memory intensive evaluations such as NixOS
-machines, i.e. in a CI context. The evaluation is done with a controllable
-number of threads that are restarted when their memory consumption exceeds a
+machines, i.e. in a CI context. The evaluation is done by a controllable number
+of worker processes that are restarted when their memory consumption exceeds a
 certain threshold.
 
 To facilitate integration, nix-eval-jobs creates garbage collection roots for
@@ -13,7 +13,7 @@ service and user-started nix builds processes.
 
 ## Why using nix-eval-jobs?
 
-- Faster evaluation by using threads
+- Faster evaluation by using multiple worker processes
 - Memory used for evaluation is reclaimed after nix-eval-jobs finish, so that
   the build can use it.
 - Evaluation of jobs can fail individually

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,7 @@ common_src = [
   'cache-status-resolver.cc',
   'daemon-settings.cc',
   'rss.cc',
+  'proc.cc',
 ]
 
 common_deps = [

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -1,18 +1,12 @@
-// NOLINTBEGIN(modernize-deprecated-headers)
-// misc-include-cleaner wants these header rather than the C++ versions
-#include <signal.h>
+// NOLINTNEXTLINE(modernize-deprecated-headers) misc-include-cleaner wants this
+// for setenv
 #include <stdlib.h>
-#include <string.h>
-// NOLINTEND(modernize-deprecated-headers)
-#include <cassert>
+#include <algorithm>
 #include <cerrno>
-#include <condition_variable>
-#include <csignal>
+#include <poll.h>
 #include <cstdlib>
-#include <cstring>
 #include <exception>
 #include <filesystem>
-#include <functional>
 #include <map>
 #include <memory>
 #include <nix/cmd/common-eval-args.hh>
@@ -24,37 +18,27 @@
 #include <nix/flake/settings.hh>
 #include <nix/main/shared.hh>
 #include <nix/store/globals.hh>
-#include <nix/store/local-fs-store.hh>
 #include <nix/util/configuration.hh>
 #include <nix/util/error.hh>
-#include <nix/util/file-descriptor.hh>
 #include <nix/util/fmt.hh>
 #include <nix/util/logging.hh>
-#include <nix/util/processes.hh>
 #include <nix/util/signals.hh> // NOLINT(misc-header-include-cycle)
 #include <nix/util/sync.hh>
 #include <nix/util/terminal.hh>
-#include <nix/util/util.hh>
 #ifdef __linux__
 #include <nix/util/linux-namespaces.hh>
 #include <nix/util/users.hh>
 #endif
-#include <sys/signal.h>
-#include <variant>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
-#include <pthread.h>
 #include <set>
-#include <fcntl.h>
-#include <nix/util/current-process.hh>
-#include <spawn.h>
 #include <span>
 #include <string>
 #include <string_view>
-#include <sys/wait.h>
 #include <unistd.h>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "eval-args.hh"
@@ -67,9 +51,7 @@
 #include "crash-handler.hh"
 #include "store.hh"
 #include "cache-status-resolver.hh"
-
-/* Not declared by <unistd.h> on all platforms. */
-extern "C" char **environ; // NOLINT(readability-redundant-declaration)
+#include "proc.hh"
 
 namespace {
 MyArgs myArgs; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -130,260 +112,14 @@ void handleConstituents(std::map<std::string, nlohmann::json> &jobs,
         resolveNamedConstituents(jobs));
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::vector<std::string> savedArgs;
-/* First message sent to every worker. */
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::string workerConfig = "{}";
+using JobMap = std::map<std::string, nlohmann::json>;
 
-/* Worker process: fork + exec of our own binary with --worker, so no
-   thread-dependent state (logger, FileTransfer) survives into it. */
-struct Proc {
-    nix::AutoCloseFD to, from;
-    nix::Pid pid;
-
-    Proc(const Proc &) = delete;
-    Proc(Proc &&) = delete;
-    auto operator=(const Proc &) -> Proc & = delete;
-    auto operator=(Proc &&) -> Proc & = delete;
-
-    Proc() {
-        nix::Pipe toPipe;
-        nix::Pipe fromPipe;
-        toPipe.create();
-        fromPipe.create();
-
-        const std::string selfExe =
-            nix::getSelfExe().value_or(savedArgs.front()).string();
-        std::vector<std::string> args = savedArgs;
-        args.emplace_back("--worker");
-        std::vector<char *> execArgv;
-        execArgv.reserve(args.size() + 1);
-        for (auto &arg : args) {
-            execArgv.push_back(arg.data());
-        }
-        execArgv.push_back(nullptr);
-
-        /* Dup above the target fds so the adddup2 sources cannot
-           collide with WORKER_OUT_FD/WORKER_IN_FD. */
-        constexpr int minFreeFd = WORKER_IN_FD + 1;
-        const nix::AutoCloseFD outFd(
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-            fcntl(fromPipe.writeSide.get(), F_DUPFD, minFreeFd));
-        const nix::AutoCloseFD inFd(
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-            fcntl(toPipe.readSide.get(), F_DUPFD, minFreeFd));
-        if (!outFd || !inFd) {
-            throw nix::SysError("duplicating worker pipe fds");
-        }
-
-        posix_spawn_file_actions_t fileActions;
-        posix_spawn_file_actions_init(&fileActions);
-        posix_spawn_file_actions_adddup2(&fileActions, outFd.get(),
-                                         WORKER_OUT_FD);
-        posix_spawn_file_actions_adddup2(&fileActions, inFd.get(),
-                                         WORKER_IN_FD);
-        pid_t childPid = -1;
-        const int err = posix_spawn(&childPid, selfExe.c_str(), &fileActions,
-                                    nullptr, execArgv.data(), environ);
-        posix_spawn_file_actions_destroy(&fileActions);
-        if (err != 0) {
-            throw nix::SysError(err, "spawning worker process");
-        }
-
-        to = std::move(toPipe.writeSide);
-        if (tryWriteLine(to.get(), workerConfig) < 0) {
-            throw nix::SysError("sending config to worker process");
-        }
-        from = std::move(fromPipe.readSide);
-        pid = childPid;
-    }
-
-    ~Proc() = default;
-};
-
-// We'd highly prefer using std::thread here; but this won't let us configure
-// the stack size. macOS uses 512KiB size stacks for non-main threads, and musl
-// defaults to 128k. While Nix configures a 64MiB size for the main thread, this
-// doesn't propagate to the threads we launch here. It turns out, running the
-// evaluator under an anemic stack of 0.5MiB has it overflow way too quickly.
-// Hence, we have our own custom Thread struct.
-// NOLINTBEGIN(misc-include-cleaner)
-// False positive: pthread.h is included but clang-tidy doesn't recognize it
-struct Thread {
-    pthread_t thread = {};
-
-    Thread(const Thread &) = delete;
-    Thread(Thread &&) noexcept = default;
-    ~Thread() = default;
-    auto operator=(const Thread &) -> Thread & = delete;
-    auto operator=(Thread &&) -> Thread & = delete;
-
-    explicit Thread(std::function<void(void)> func) {
-        pthread_attr_t attr = {};
-
-        auto funcPtr =
-            std::make_unique<std::function<void(void)>>(std::move(func));
-
-        int status = pthread_attr_init(&attr);
-        if (status != 0) {
-            throw nix::SysError(status, "calling pthread_attr_init");
-        }
-
-        struct AttrGuard {
-            pthread_attr_t &attr;
-            explicit AttrGuard(pthread_attr_t &attribute) : attr(attribute) {}
-            AttrGuard(const AttrGuard &) = delete;
-            auto operator=(const AttrGuard &) -> AttrGuard & = delete;
-            AttrGuard(AttrGuard &&) = delete;
-            auto operator=(AttrGuard &&) -> AttrGuard & = delete;
-            ~AttrGuard() { (void)pthread_attr_destroy(&attr); }
-        };
-        const AttrGuard attrGuard(attr);
-
-        static constexpr size_t STACK_SIZE_MB = 64;
-        static constexpr size_t KB_SIZE = 1024;
-        status = pthread_attr_setstacksize(
-            &attr, static_cast<size_t>(STACK_SIZE_MB) * KB_SIZE * KB_SIZE);
-        if (status != 0) {
-            throw nix::SysError(status, "calling pthread_attr_setstacksize");
-        }
-        status = pthread_create(&thread, &attr, Thread::init, funcPtr.get());
-        if (status != 0) {
-            throw nix::SysError(status, "calling pthread_launch");
-        }
-        [[maybe_unused]] auto *res =
-            funcPtr.release(); // will be deleted in init()
-    }
-
-    void join() const {
-        const int status = pthread_join(thread, nullptr);
-        if (status != 0) {
-            throw nix::SysError(status, "calling pthread_join");
-        }
-    }
-
-  private:
-    static auto init(void *ptr) -> void * {
-        std::unique_ptr<std::function<void(void)>> func;
-        func.reset(static_cast<std::function<void(void)> *>(ptr));
-
-        (*func)();
-        return nullptr;
-    }
-};
-// NOLINTEND(misc-include-cleaner)
-
-struct State {
-    std::set<nlohmann::json> todo =
-        nlohmann::json::array({nlohmann::json::array()});
-    std::set<nlohmann::json> active;
-    std::map<std::string, nlohmann::json> jobs;
-    std::exception_ptr exc;
-};
-
-void handleBrokenWorkerPipe(Proc &proc, std::string_view msg) {
-    // we already took the process status from Proc, no
-    // need to wait for it again to avoid error messages
-    // NOLINTNEXTLINE(misc-include-cleaner)
-    const pid_t pid = proc.pid.release();
-    while (true) {
-        int status = 0;
-        const int result = waitpid(pid, &status, WNOHANG);
-        if (result == 0) {
-            kill(pid, SIGKILL);
-            throw nix::Error(
-                "BUG: while %s, worker pipe got closed but evaluation "
-                "worker still running?",
-                msg);
-        }
-
-        if (result == -1) {
-            kill(pid, SIGKILL);
-            throw nix::SysError("BUG: while %s, waitpid for evaluation "
-                                "worker failed",
-                                msg);
-        }
-        if (WIFEXITED(status)) {
-            if (WEXITSTATUS(status) == 1) {
-                throw nix::Error(
-                    "while %s, evaluation worker exited with exit code 1, "
-                    "(possible infinite recursion)",
-                    msg);
-            }
-            throw nix::Error("while %s, evaluation worker exited with %d", msg,
-                             WEXITSTATUS(status));
-        }
-
-        if (WIFSIGNALED(status)) {
-            switch (WTERMSIG(status)) {
-            case SIGKILL:
-                throw nix::Error(
-                    "while %s, evaluation worker got killed by SIGKILL, "
-                    "maybe "
-                    "memory limit reached?",
-                    msg);
-                break;
-            default:
-                throw nix::Error(
-                    "while %s, evaluation worker crashed with signal %d "
-                    "(%s); enable coredumps for a backtrace",
-                    msg, WTERMSIG(status),
-                    // constant strings on glibc >= 2.32 and macOS
-                    // NOLINTNEXTLINE(concurrency-mt-unsafe)
-                    strsignal(WTERMSIG(status)));
-            }
-        } // else ignore WIFSTOPPED and WIFCONTINUED
-    }
-}
-
-namespace {
-auto checkWorkerStatus(LineReader *fromReader, Proc *proc) -> std::string_view {
-    auto line = fromReader->readLine();
-    if (line.empty()) {
-        handleBrokenWorkerPipe(*proc, "checking worker process");
-    }
-    if (line != MSG_NEXT && line != MSG_RESTART) {
-        try {
-            auto json = nlohmann::json::parse(line);
-            throw nix::Error("worker error: %s", std::string(json["error"]));
-        } catch (const nlohmann::json::exception &e) {
-            throw nix::Error(
-                "Received invalid JSON from worker: %s\n json: '%s'", e.what(),
-                line);
-        }
-    }
-    return line;
-}
-
-auto getNextJob(nix::Sync<State> &state_, std::condition_variable &wakeup)
-    -> std::optional<nlohmann::json> {
-    nlohmann::json attrPath;
-    while (true) {
-        nix::checkInterrupt();
-        auto state(state_.lock());
-        if ((state->todo.empty() && state->active.empty()) || state->exc) {
-            return std::nullopt;
-        }
-        if (!state->todo.empty()) {
-            attrPath = *state->todo.begin();
-            state->todo.erase(state->todo.begin());
-            state->active.insert(attrPath);
-            return attrPath;
-        }
-        state.wait(wakeup);
-    }
-}
-
-/* Record a finished job/error in the shared state and print it,
-   unless it is an aggregate that still awaits its constituents (then
-   handleConstituents prints it later). */
-void emitResponse(nix::Sync<State> &state_, const Response &response,
-                  nlohmann::json jsonResponse, std::string_view dumped) {
-    {
-        auto state(state_.lock());
-        state->jobs.insert_or_assign(response.attr, std::move(jsonResponse));
-    }
+/* Record a finished job/error and print it, unless it is an aggregate
+   that still awaits its constituents (handleConstituents prints it
+   later). Also called from the CacheStatusResolver thread. */
+void emitResponse(nix::Sync<JobMap> &jobs, const Response &response,
+                  nlohmann::json json, std::string_view dumped) {
+    jobs.lock()->insert_or_assign(response.attr, std::move(json));
 
     bool hasPendingConstituents = false;
     if (const auto *job = std::get_if<Response::Job>(&response.payload)) {
@@ -395,137 +131,225 @@ void emitResponse(nix::Sync<State> &state_, const Response &response,
     }
 }
 
-auto processWorkerResponse(LineReader *fromReader,
-                           const nlohmann::json &attrPath, Proc *proc,
-                           nix::Sync<State> &state_,
-                           CacheStatusResolver *cacheStatusResolver)
-    -> std::vector<nlohmann::json> {
-    // Read response from worker
-    auto respString = fromReader->readLine();
-    if (respString.empty()) {
-        auto msg =
-            "reading result for attrPath '" + joinAttrPath(attrPath) + "'";
-        handleBrokenWorkerPipe(*proc, msg);
-    }
+void emitResponse(nix::Sync<JobMap> &jobs, const Response &response) {
+    nlohmann::json json = response;
+    auto dumped = json.dump();
+    emitResponse(jobs, response, std::move(json), dumped);
+}
 
-    // Parse and deserialize the typed response
-    nlohmann::json jsonResponse;
+auto parseResponse(std::string_view line)
+    -> std::pair<Response, nlohmann::json> {
     try {
-        jsonResponse = nlohmann::json::parse(respString);
+        auto json = nlohmann::json::parse(line);
+        auto response = json.get<Response>();
+        return {std::move(response), std::move(json)};
     } catch (const nlohmann::json::exception &e) {
         throw nix::Error("Received invalid JSON from worker: %s\n json: '%s'",
-                         e.what(), respString);
+                         e.what(), line);
     }
-    auto response = jsonResponse.get<Response>();
+}
 
-    // Dispatch on the response payload
-    std::vector<nlohmann::json> newAttrs;
-    if (auto *attrs = std::get_if<Response::Attrs>(&response.payload)) {
-        for (const auto &attr : attrs->attrs) {
-            nlohmann::json newAttr(response.attrPath);
-            newAttr.emplace_back(attr);
-            newAttrs.push_back(newAttr);
-        }
-    } else if ((cacheStatusResolver != nullptr) &&
-               std::holds_alternative<Response::Job>(response.payload)) {
-        // The resolver fills in cacheStatus, then records/prints the job
-        // via its sink.
-        cacheStatusResolver->push(std::move(response));
-    } else {
-        emitResponse(state_, response, std::move(jsonResponse), respString);
+/* Single-threaded event loop over the worker pipes: spawns workers,
+   hands out jobs and collects results. */
+class Scheduler {
+  public:
+    Scheduler(const MyArgs &args, const WorkerSpawnConfig &spawn,
+              CacheStatusResolver *cacheStatusResolver, nix::Sync<JobMap> &jobs)
+        : spawn(spawn), cacheStatusResolver(cacheStatusResolver), jobs(jobs),
+          workers(args.nrWorkers) {
+        todo.insert(nlohmann::json::array());
+    }
 
-        if (auto *error = std::get_if<Response::Error>(&response.payload);
-            (error != nullptr) && error->fatal) {
-            throw nix::Error("%s", error->error);
+    void run() {
+        while (!finished() || anyWorkerAlive()) {
+            nix::checkInterrupt();
+            dispatch();
+            pollWorkers();
         }
     }
 
-    return newAttrs;
-}
+  private:
+    enum class Phase { None, Starting, Idle, Busy, Exiting };
+    struct Worker {
+        std::unique_ptr<Proc> proc;
+        Phase phase = Phase::None;
+        nlohmann::json attrPath;
+    };
 
-void updateJobQueue(nix::Sync<State> &state_, std::condition_variable &wakeup,
-                    const nlohmann::json &attrPath,
-                    const std::vector<nlohmann::json> &newAttrs) {
-    auto state(state_.lock());
-    state->active.erase(attrPath);
-    for (const auto &newAttr : newAttrs) {
-        state->todo.insert(newAttr);
+    const WorkerSpawnConfig &spawn;
+    CacheStatusResolver *cacheStatusResolver;
+    nix::Sync<JobMap> &jobs;
+
+    std::set<nlohmann::json> todo;
+    std::vector<Worker> workers;
+
+    [[nodiscard]] auto finished() const -> bool {
+        return todo.empty() && count(Phase::Busy) == 0;
     }
-    wakeup.notify_all();
-}
-} // namespace
+
+    [[nodiscard]] auto anyWorkerAlive() const -> bool {
+        return std::ranges::any_of(
+            workers, [](const Worker &w) -> bool { return w.proc != nullptr; });
+    }
+
+    [[nodiscard]] auto count(Phase phase) const -> size_t {
+        return static_cast<size_t>(
+            std::ranges::count_if(workers, [phase](const Worker &w) -> bool {
+                return w.phase == phase;
+            }));
+    }
+
+    auto takeJob() -> std::optional<nlohmann::json> {
+        if (todo.empty()) {
+            return std::nullopt;
+        }
+        auto attrPath = *todo.begin();
+        todo.erase(todo.begin());
+        return attrPath;
+    }
+
+    void resetWorker(size_t idx) { workers[idx] = Worker{}; }
+
+    void dispatch() {
+        /* Don't spawn more workers than there are jobs to hand out. */
+        size_t spawnable = todo.size();
+        spawnable -= std::min(spawnable, count(Phase::Starting));
+
+        for (size_t idx = 0; idx < workers.size(); idx++) {
+            Worker &w = workers[idx];
+            if (w.phase == Phase::Idle && finished()) {
+                (void)w.proc->sendLine(MSG_EXIT);
+                w.phase = Phase::Exiting;
+            } else if (w.phase == Phase::Idle) {
+                if (auto attrPath = takeJob()) {
+                    w.attrPath = std::move(*attrPath);
+                    w.phase = Phase::Busy;
+                    if (!w.proc->sendLine(std::string(MSG_DO) +
+                                          w.attrPath.dump())) {
+                        onEof(idx);
+                    }
+                }
+            } else if (w.phase == Phase::None && spawnable > 0 && !finished()) {
+                w.proc = std::make_unique<Proc>(spawn);
+                w.phase = Phase::Starting;
+                spawnable--;
+            }
+        }
+    }
+
+    void pollWorkers() {
+        std::vector<pollfd> fds;
+        std::vector<size_t> owner;
+        for (size_t idx = 0; idx < workers.size(); idx++) {
+            if (workers[idx].proc) {
+                fds.push_back({.fd = workers[idx].proc->readFd(),
+                               .events = POLLIN,
+                               .revents = 0});
+                owner.push_back(idx);
+            }
+        }
+        const int n = poll(fds.data(), fds.size(), -1);
+        if (n == -1 && errno != EINTR) {
+            throw nix::SysError("polling workers");
+        }
+
+        for (size_t i = 0; i < fds.size(); i++) {
+            if ((fds[i].revents & (POLLIN | POLLHUP | POLLERR)) != 0) {
+                readWorker(owner[i]);
+            }
+        }
+    }
+
+    void readWorker(size_t idx) {
+        Worker &w = workers[idx];
+        const bool eof = !w.proc->fill();
+        while (w.proc) {
+            auto line = w.proc->popLine();
+            if (!line) {
+                break;
+            }
+            onLine(idx, *line);
+        }
+        if (eof && w.proc) {
+            onEof(idx);
+        }
+    }
+
+    void onLine(size_t idx, std::string_view line) {
+        switch (workers[idx].phase) {
+        case Phase::Starting:
+            if (line == MSG_NEXT) {
+                workers[idx].phase = Phase::Idle;
+            } else if (line == MSG_RESTART) {
+                resetWorker(idx);
+            } else {
+                auto json = nlohmann::json::parse(line, nullptr, false);
+                if (json.is_object() && json.contains("error")) {
+                    throw nix::Error("worker error: %s",
+                                     std::string(json["error"]));
+                }
+                throw nix::Error("unexpected line from worker: '%s'", line);
+            }
+            break;
+        case Phase::Busy:
+            onResponse(idx, line);
+            break;
+        case Phase::Exiting:
+            break;
+        default:
+            throw nix::Error("unexpected line from idle worker: '%s'", line);
+        }
+    }
+
+    void onResponse(size_t idx, std::string_view line) {
+        auto [response, json] = parseResponse(line);
+
+        if (auto *attrs = std::get_if<Response::Attrs>(&response.payload)) {
+            for (const auto &attr : attrs->attrs) {
+                nlohmann::json child(response.attrPath);
+                child.emplace_back(attr);
+                todo.insert(std::move(child));
+            }
+        } else if (cacheStatusResolver != nullptr &&
+                   std::holds_alternative<Response::Job>(response.payload)) {
+            // The resolver fills in cacheStatus and emits via its sink.
+            cacheStatusResolver->push(std::move(response));
+        } else {
+            emitResponse(jobs, response, std::move(json), line);
+            if (auto *error = std::get_if<Response::Error>(&response.payload);
+                error != nullptr && error->fatal) {
+                throw nix::Error("%s", error->error);
+            }
+        }
+
+        workers[idx].phase = Phase::Starting;
+        workers[idx].attrPath = nullptr;
+    }
+
+    void onEof(size_t idx) {
+        Worker &w = workers[idx];
+        if (w.phase == Phase::Exiting) {
+            resetWorker(idx);
+            return;
+        }
+        w.proc->throwExited(w.phase == Phase::Busy
+                                ? "evaluating '" + joinAttrPath(w.attrPath) +
+                                      "'"
+                                : "starting worker");
+    }
+};
 
 /* Rationale for the separate resolver: see CacheStatusResolver. */
-auto makeCacheStatusResolver(const MyArgs &args, nix::Sync<State> &state_)
+auto makeCacheStatusResolver(const MyArgs &args, nix::Sync<JobMap> &jobs)
     -> std::optional<CacheStatusResolver> {
     if (!args.checkCacheStatus) {
         return std::nullopt;
     }
     return std::optional<CacheStatusResolver>(
         std::in_place, nix_eval_jobs::openStore(args.evalStoreUrl),
-        nix_eval_jobs::openStore(),
-        [&state_](const Response &response) -> void {
-            nlohmann::json jsonResponse = response;
-            auto dumped = jsonResponse.dump();
-            emitResponse(state_, response, std::move(jsonResponse), dumped);
+        nix_eval_jobs::openStore(), [&jobs](const Response &response) -> void {
+            emitResponse(jobs, response);
         });
-}
-
-void collector(nix::Sync<State> &state_, std::condition_variable &wakeup,
-               CacheStatusResolver *cacheStatusResolver) {
-    try {
-        std::unique_ptr<Proc> proc;
-        std::unique_ptr<LineReader> fromReader;
-
-        while (true) {
-            // Claim a job before forking so over-provisioned workers stay idle
-            auto maybeAttrPath = getNextJob(state_, wakeup);
-            if (!maybeAttrPath.has_value()) {
-                /* A worker whose pending status line is MSG_RESTART
-                   has already closed its pipe and is exiting on its
-                   own. */
-                if (proc &&
-                    checkWorkerStatus(fromReader.get(), proc.get()) !=
-                        MSG_RESTART &&
-                    tryWriteLine(proc->to.get(), std::string(MSG_EXIT)) < 0) {
-                    handleBrokenWorkerPipe(*proc, "sending exit");
-                }
-                return;
-            }
-            const auto &attrPath = maybeAttrPath.value();
-
-            // Ensure we have a worker that is ready for a job
-            while (true) {
-                if (!proc) {
-                    proc = std::make_unique<Proc>();
-                    fromReader =
-                        std::make_unique<LineReader>(proc->from.release());
-                }
-                auto line = checkWorkerStatus(fromReader.get(), proc.get());
-                if (line != MSG_RESTART) {
-                    break;
-                }
-                proc.reset();
-                fromReader.reset();
-            }
-
-            if (tryWriteLine(proc->to.get(),
-                             std::string(MSG_DO) + attrPath.dump()) < 0) {
-                auto msg = "sending attrPath '" + joinAttrPath(attrPath) + "'";
-                handleBrokenWorkerPipe(*proc, msg);
-            }
-
-            auto newAttrs =
-                processWorkerResponse(fromReader.get(), attrPath, proc.get(),
-                                      state_, cacheStatusResolver);
-
-            updateJobQueue(state_, wakeup, attrPath, newAttrs);
-        }
-    } catch (...) {
-        auto state(state_.lock());
-        state->exc = std::current_exception();
-        wakeup.notify_all();
-    }
 }
 
 void validateIncompatibleFlags(const MyArgs &args) {
@@ -620,71 +444,46 @@ auto main(int argc, char **argv) -> int {
             return;
         }
 
-        savedArgs.assign(args.begin(), args.end());
+        WorkerSpawnConfig spawn{.argv = {args.begin(), args.end()}};
 
-        nix::Sync<State> state_;
+        nix::Sync<JobMap> jobs;
 
         /* Pre-initialize the eval store (if specified) before spawning
            workers so that the SQLite database and schema are created
-           exactly once.  Without this, forked workers race to create
+           exactly once.  Without this, workers race to create
            a fresh store and hit SQLite "busy" / "schema is corrupt"
            errors.  See https://github.com/NixOS/nix-eval-jobs/issues/401 */
         if (myArgs.evalStoreUrl.has_value()) {
             nix_eval_jobs::openStore(myArgs.evalStoreUrl);
         }
 
-        /* The fetcher cache is opened lazily on first fetch, so forked
+        /* The fetcher cache is opened lazily on first fetch, so
            workers would otherwise race to create fetcher-cache-v4.sqlite and
            fail with "unable to open database file". Open it once here. */
         nix::fetchSettings.getCache();
 
         if (myArgs.flake) {
             if (auto lockedAttrs = prefetchFlake(myArgs)) {
-                workerConfig =
+                spawn.config =
                     nlohmann::json{{"lockedFlake", *lockedAttrs}}.dump();
             }
         }
 
-        auto cacheStatusResolver = makeCacheStatusResolver(myArgs, state_);
-        auto *cacheStatusResolverPtr =
-            cacheStatusResolver ? &*cacheStatusResolver : nullptr;
+        auto cacheStatusResolver = makeCacheStatusResolver(myArgs, jobs);
 
-        /* Start a collector thread per worker process. */
-        std::vector<Thread> threads;
-        std::condition_variable wakeup;
-        threads.reserve(myArgs.nrWorkers);
-        for (size_t i = 0; i < myArgs.nrWorkers; i++) {
-            threads.emplace_back(
-                [&state_, &wakeup, cacheStatusResolverPtr] -> void {
-                    collector(state_, wakeup, cacheStatusResolverPtr);
-                });
-        }
+        /* A scheduler error propagates from here so the
+           CacheStatusResolver destructor discards its backlog instead
+           of finish() draining it (and masking the eval error). */
+        Scheduler(myArgs, spawn,
+                  cacheStatusResolver ? &*cacheStatusResolver : nullptr, jobs)
+            .run();
 
-        for (auto &thread : threads) {
-            thread.join();
-        }
-
-        /* A collector error must surface immediately: rethrowing it
-           here lets the CacheStatusResolver destructor discard the
-           backlog instead of finish() draining it first (which would
-           also mask the eval error with any resolver error). */
-        {
-            auto state(state_.lock());
-            if (state->exc) {
-                std::rethrow_exception(state->exc);
-            }
-        }
-
-        /* All eval results are in; wait for outstanding cache-status
-           checks before constituents are aggregated. */
         if (cacheStatusResolver) {
             cacheStatusResolver->finish();
         }
 
-        auto state(state_.lock());
-
         if (myArgs.constituents) {
-            handleConstituents(state->jobs, myArgs);
+            handleConstituents(*jobs.lock(), myArgs);
         }
     });
 }

--- a/src/proc.cc
+++ b/src/proc.cc
@@ -1,0 +1,156 @@
+// NOLINTBEGIN(modernize-deprecated-headers)
+// misc-include-cleaner wants these headers rather than the C++ versions
+#include <signal.h>
+#include <string.h>
+// NOLINTEND(modernize-deprecated-headers)
+#include <cerrno>
+#include <cstddef>
+#include <fcntl.h>
+#include <nix/util/current-process.hh>
+#include <nix/util/error.hh>
+#include <nix/util/file-descriptor.hh>
+#include <nix/util/processes.hh>
+#include <optional>
+#include <spawn.h>
+#include <string>
+#include <string_view>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+#include "buffered-io.hh"
+#include "proc.hh"
+#include "worker.hh"
+
+/* Not declared by <unistd.h> on all platforms. */
+extern "C" char **environ; // NOLINT(readability-redundant-declaration)
+
+Proc::Proc(const WorkerSpawnConfig &spawn) {
+    nix::Pipe toPipe;
+    nix::Pipe fromPipe;
+    toPipe.create();
+    fromPipe.create();
+
+    const std::string selfExe =
+        nix::getSelfExe().value_or(spawn.argv.front()).string();
+    std::vector<std::string> args = spawn.argv;
+    args.emplace_back("--worker");
+    std::vector<char *> execArgv;
+    execArgv.reserve(args.size() + 1);
+    for (auto &arg : args) {
+        execArgv.push_back(arg.data());
+    }
+    execArgv.push_back(nullptr);
+
+    /* Dup above the target fds so the adddup2 sources cannot collide
+       with WORKER_OUT_FD/WORKER_IN_FD. */
+    constexpr int minFreeFd = WORKER_IN_FD + 1;
+    const nix::AutoCloseFD outFd(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        fcntl(fromPipe.writeSide.get(), F_DUPFD, minFreeFd));
+    const nix::AutoCloseFD inFd(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+        fcntl(toPipe.readSide.get(), F_DUPFD, minFreeFd));
+    if (!outFd || !inFd) {
+        throw nix::SysError("duplicating worker pipe fds");
+    }
+
+    posix_spawn_file_actions_t fileActions;
+    posix_spawn_file_actions_init(&fileActions);
+    posix_spawn_file_actions_adddup2(&fileActions, outFd.get(), WORKER_OUT_FD);
+    posix_spawn_file_actions_adddup2(&fileActions, inFd.get(), WORKER_IN_FD);
+    pid_t childPid = -1;
+    const int err = posix_spawn(&childPid, selfExe.c_str(), &fileActions,
+                                nullptr, execArgv.data(), environ);
+    posix_spawn_file_actions_destroy(&fileActions);
+    if (err != 0) {
+        throw nix::SysError(err, "spawning worker process");
+    }
+    proc = childPid;
+    pid_ = childPid;
+
+    to = std::move(toPipe.writeSide);
+    from = std::move(fromPipe.readSide);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    if (fcntl(from.get(), F_SETFL, O_NONBLOCK) == -1) {
+        throw nix::SysError("making worker pipe non-blocking");
+    }
+    if (!sendLine(spawn.config)) {
+        throw nix::SysError("sending config to worker process");
+    }
+}
+
+auto Proc::sendLine(std::string_view line) -> bool {
+    return tryWriteLine(to.get(), std::string(line)) == 0;
+}
+
+auto Proc::fill() -> bool {
+    static constexpr size_t CHUNK = 64 * 1024;
+    while (true) {
+        const size_t old = buf.size();
+        buf.resize(old + CHUNK);
+        const ssize_t n = ::read(from.get(), buf.data() + old, CHUNK);
+        if (n > 0) {
+            buf.resize(old + static_cast<size_t>(n));
+            continue;
+        }
+        buf.resize(old);
+        if (n == 0) {
+            return false;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return true;
+        }
+        if (errno != EINTR) {
+            throw nix::SysError("reading from worker");
+        }
+    }
+}
+
+auto Proc::popLine() -> std::optional<std::string> {
+    const auto nl = buf.find('\n', scanned);
+    if (nl == std::string::npos) {
+        scanned = buf.size();
+        return std::nullopt;
+    }
+    std::string line = buf.substr(0, nl);
+    buf.erase(0, nl + 1);
+    scanned = 0;
+    return line;
+}
+
+void Proc::throwExited(std::string_view doing) {
+    // NOLINTNEXTLINE(misc-include-cleaner)
+    const pid_t child = proc.release();
+    int status = 0;
+    // Pipe EOF can be observed before a SIGKILLed worker is reapable.
+    int result = waitpid(child, &status, WNOHANG);
+    if (result == 0) {
+        kill(child, SIGKILL);
+        result = waitpid(child, &status, 0);
+    }
+    if (result == -1) {
+        throw nix::SysError("while %s, waitpid for evaluation worker failed",
+                            doing);
+    }
+    if (WIFSIGNALED(status)) {
+        if (WTERMSIG(status) == SIGKILL) {
+            throw nix::Error("while %s, evaluation worker got killed by "
+                             "SIGKILL, maybe memory limit reached?",
+                             doing);
+        }
+        throw nix::Error("while %s, evaluation worker crashed with signal %d "
+                         "(%s); enable coredumps for a backtrace",
+                         doing, WTERMSIG(status),
+                         // NOLINTNEXTLINE(concurrency-mt-unsafe)
+                         strsignal(WTERMSIG(status)));
+    }
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 1) {
+        throw nix::Error("while %s, evaluation worker exited with exit code "
+                         "1 (possible infinite recursion)",
+                         doing);
+    }
+    throw nix::Error("while %s, evaluation worker exited with %d", doing,
+                     WEXITSTATUS(status));
+}

--- a/src/proc.hh
+++ b/src/proc.hh
@@ -1,0 +1,49 @@
+#pragma once
+///@file
+
+#include <nix/util/file-descriptor.hh>
+#include <nix/util/processes.hh>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+struct WorkerSpawnConfig {
+    std::vector<std::string> argv;
+    /* First line sent to every worker. */
+    std::string config = "{}";
+};
+
+/* A worker: our own binary spawned with --worker so it starts from a
+   clean process (no inherited logger/FileTransfer state). The read side
+   is non-blocking and line-buffered for use with poll(). */
+class Proc {
+  public:
+    explicit Proc(const WorkerSpawnConfig &spawn);
+    Proc(const Proc &) = delete;
+    Proc(Proc &&) = delete;
+    auto operator=(const Proc &) -> Proc & = delete;
+    auto operator=(Proc &&) -> Proc & = delete;
+    ~Proc() = default;
+
+    [[nodiscard]] auto pid() const -> pid_t { return pid_; }
+    [[nodiscard]] auto readFd() const -> int { return from.get(); }
+
+    /* False if the worker is gone. */
+    [[nodiscard]] auto sendLine(std::string_view line) -> bool;
+
+    /* Read what is available. False on EOF. */
+    [[nodiscard]] auto fill() -> bool;
+    auto popLine() -> std::optional<std::string>;
+
+    /* Reap a worker whose pipe closed and throw a matching error. */
+    [[noreturn]] void throwExited(std::string_view doing);
+
+  private:
+    nix::AutoCloseFD to;
+    nix::AutoCloseFD from;
+    nix::Pid proc;
+    pid_t pid_ = -1;
+    std::string buf;
+    size_t scanned = 0;
+};


### PR DESCRIPTION
The collector threads did no evaluation anymore, they only blocked on
one worker pipe each. That forced the job queue behind a mutex and
condition variable and kept a custom 64 MiB-stack pthread wrapper whose
rationale (forked evaluators inheriting the thread stack) went away
with posix_spawn.

A single Scheduler now polls all worker pipes. Worker process plumbing
moves to proc.cc, with a non-blocking line buffer replacing the
FILE*-based LineReader on the collector side and an explicit per-worker
Phase instead of implicit position in a thread's loop. Only the job map
is still shared with the CacheStatusResolver thread.

Also fixes a race in the broken-pipe handling: pipe EOF can be seen
before a killed worker is reapable, which was reported as a BUG.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>