### PR TITLE
Attach evaluation warnings and traces to each attribute's JSON line

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ If you provide the `--check-cache-status`, the json will contain a
 | cached   | Package is present in the binary cache, but not locally |
 | notBuilt | Package needs to be built.                              |
 
+### Where do evaluation warnings and traces end up?
+
+Messages from `builtins.warn` and `builtins.trace` are printed to stderr as
+usual and additionally attached to the JSON line of the attribute that was being
+evaluated, as `"warnings": [...]` and `"traces": [...]` (omitted when empty).
+Because Nix evaluates shared values only once, a message from code shared
+between attributes is reported on whichever attribute forced it first.
+
 ### How can I evaluate nixpkgs?
 
 If you want to evaluate nixpkgs in the same way

--- a/src/eval-log.cc
+++ b/src/eval-log.cc
@@ -1,0 +1,47 @@
+#include <nix/util/error.hh>
+#include <nix/util/logging.hh>
+#include <nix/util/terminal.hh>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "eval-log.hh"
+
+namespace {
+constexpr std::string_view TRACE_PREFIX = "trace: ";
+}
+
+EvalLogCapture::EvalLogCapture(nix::Logger *inner) : inner(inner) {}
+
+/* Lives for the rest of the worker process, like the logger it wraps. */
+auto EvalLogCapture::install() -> EvalLogCapture & {
+    auto *self = new EvalLogCapture(
+        nix::logger); // NOLINT(cppcoreguidelines-owning-memory)
+    nix::logger = self;
+    return *self;
+}
+
+auto EvalLogCapture::take() -> Logs { return std::exchange(logs, {}); }
+
+/* builtins.trace → printError("trace: …") */
+void EvalLogCapture::log(nix::Verbosity lvl, std::string_view msg) {
+    auto plain = nix::filterANSIEscapes(msg, true);
+    if (plain.starts_with(TRACE_PREFIX)) {
+        logs.traces.push_back(plain.substr(TRACE_PREFIX.size()));
+    }
+    inner->log(lvl, msg);
+}
+
+/* builtins.warn → logWarning(ErrorInfo{lvlWarn, …}) */
+void EvalLogCapture::logEI(const nix::ErrorInfo &info) {
+    if (info.level == nix::lvlWarn) {
+        logs.warnings.push_back(nix::filterANSIEscapes(info.msg.str(), true));
+    }
+    inner->logEI(info);
+}
+
+/* nix::warn(), e.g. deprecated settings or impure fetches */
+void EvalLogCapture::warn(const std::string &msg) {
+    logs.warnings.push_back(nix::filterANSIEscapes(msg, true));
+    inner->warn(msg);
+}

--- a/src/eval-log.hh
+++ b/src/eval-log.hh
@@ -1,0 +1,60 @@
+#pragma once
+///@file
+
+#include <nix/util/error.hh>
+#include <nix/util/logging.hh>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+/* Wraps the worker's logger to record `builtins.warn` and
+   `builtins.trace` messages of the attribute currently being evaluated,
+   so the collector can attach them to that attribute's JSON line.
+   Everything is still forwarded to stderr unchanged. */
+class EvalLogCapture : public nix::Logger {
+  public:
+    struct Logs {
+        std::vector<std::string> warnings;
+        std::vector<std::string> traces;
+        bool operator==(const Logs &) const = default;
+    };
+
+    explicit EvalLogCapture(nix::Logger *inner);
+
+    /* Install as nix::logger and return a handle for take(). */
+    static auto install() -> EvalLogCapture &;
+
+    auto take() -> Logs;
+
+    void stop() override { inner->stop(); }
+    void pause() override { inner->pause(); }
+    void resume() override { inner->resume(); }
+    auto isVerbose() -> bool override { return inner->isVerbose(); }
+    void log(nix::Verbosity lvl, std::string_view msg) override;
+    void logEI(const nix::ErrorInfo &info) override;
+    void warn(const std::string &msg) override;
+    void startActivity(nix::ActivityId act, nix::Verbosity lvl,
+                       nix::ActivityType type, const std::string &text,
+                       const Fields &fields, nix::ActivityId parent) override {
+        inner->startActivity(act, lvl, type, text, fields, parent);
+    }
+    void stopActivity(nix::ActivityId act) override {
+        inner->stopActivity(act);
+    }
+    void result(nix::ActivityId act, nix::ResultType type,
+                const Fields &fields) override {
+        inner->result(act, type, fields);
+    }
+    void writeToStdout(std::string_view data) override {
+        inner->writeToStdout(data);
+    }
+    auto ask(std::string_view msg) -> std::optional<char> override {
+        return inner->ask(msg);
+    }
+    void setPrintBuildLogs(bool on) override { inner->setPrintBuildLogs(on); }
+
+  private:
+    nix::Logger *inner;
+    Logs logs;
+};

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 common_src = [
   'eval-args.cc',
+  'eval-log.cc',
   'drv.cc',
   'response.cc',
   'buffered-io.cc',

--- a/src/response.cc
+++ b/src/response.cc
@@ -38,6 +38,12 @@ void adl_serializer<Response>::to_json(json &res, const Response &response) {
         {"attr", response.attr},
         {"attrPath", response.attrPath},
     };
+    if (!response.warnings.empty()) {
+        res["warnings"] = response.warnings;
+    }
+    if (!response.traces.empty()) {
+        res["traces"] = response.traces;
+    }
 
     std::visit(overloaded{
                    [&](const Response::Job &job) -> void {
@@ -64,11 +70,18 @@ auto adl_serializer<Response>::from_json(const json &_json) -> Response {
     auto attr = getString(valueAt(json, "attr"));
     std::vector<std::string> attrPath = valueAt(json, "attrPath");
 
+    auto stringList = [&](const char *key) -> std::vector<std::string> {
+        const auto *v = get(json, key);
+        return v ? v->get<std::vector<std::string>>()
+                 : std::vector<std::string>{};
+    };
     auto makeResponse = [&](Response::Payload payload) -> Response {
         return Response{
             .attr = std::move(attr),
             .attrPath = std::move(attrPath),
             .payload = std::move(payload),
+            .warnings = stringList("warnings"),
+            .traces = stringList("traces"),
         };
     };
 

--- a/src/response.hh
+++ b/src/response.hh
@@ -47,6 +47,12 @@ struct Response {
     using Payload = std::variant<Job, Attrs, Error>;
     Payload payload;
 
+    /* builtins.warn / builtins.trace output emitted while evaluating this
+       attribute. Shared thunks only log the first time they are forced,
+       so a message shows up on whichever attribute got there first. */
+    std::vector<std::string> warnings = {};
+    std::vector<std::string> traces = {};
+
     bool operator==(const Response &) const = default;
 };
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -49,6 +49,7 @@
 #include "response.hh"
 #include "buffered-io.hh"
 #include "eval-args.hh"
+#include "eval-log.hh"
 #include "store.hh"
 #include "rss.hh"
 
@@ -303,6 +304,7 @@ struct Evaluator {
     nix::Bindings &autoArgs;
     nix::Value *vRoot;
     MyArgs &args;
+    EvalLogCapture &logCapture;
 
     auto evaluate(const nlohmann::json &path) -> Response::Payload {
         auto attrPathS = joinAttrPath(path);
@@ -351,10 +353,15 @@ auto processJobRequest(Evaluator &evaluator, LineReader &fromReader,
     }
     auto path = nlohmann::json::parse(line.substr(MSG_DO.size()));
 
+    evaluator.logCapture.take(); // drop noise from between jobs
+    auto payload = evaluator.evaluate(path);
+    auto logs = evaluator.logCapture.take();
     const Response response{
         .attr = joinAttrPath(path),
         .attrPath = path.get<std::vector<std::string>>(),
-        .payload = evaluator.evaluate(path),
+        .payload = std::move(payload),
+        .warnings = std::move(logs.warnings),
+        .traces = std::move(logs.traces),
     };
     if (tryWriteLine(toParent.get(), nlohmann::json(response).dump()) < 0) {
         return false;
@@ -404,6 +411,7 @@ void worker(
         .autoArgs = autoArgs,
         .vRoot = initializeRootValue(state, autoArgs, args),
         .args = args,
+        .logCapture = EvalLogCapture::install(),
     };
 
     while (processJobRequest(evaluator, fromReader, toParent)) {

--- a/tests-functional/assets/flake.nix
+++ b/tests-functional/assets/flake.nix
@@ -106,6 +106,21 @@
               brokenPkgs = {
                 brokenPackage = throw "this is an evaluation error";
               };
+              loggingPkgs =
+                let
+                  mk =
+                    name:
+                    derivation {
+                      inherit name system;
+                      builder = "/bin/sh";
+                    };
+                in
+                {
+                  warns = builtins.warn "first warning" (builtins.warn "second warning" (mk "warns"));
+                  traces = builtins.trace "hello from trace" (mk "traces");
+                  quiet = mk "quiet";
+                  warnThenThrow = builtins.warn "about to fail" (throw "failed");
+                };
               infiniteRecursionPkgs = {
                 packageWithInfiniteRecursion =
                   let

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -136,6 +136,33 @@ def test_eval_error() -> None:
         assert "this is an evaluation error" in attrs["error"]
 
 
+def test_eval_logs_per_attr() -> None:
+    cmd = [
+        str(BIN),
+        "--workers",
+        "1",
+        *COMMON_FLAGS,
+        "--flake",
+        ".#legacyPackages.x86_64-linux.loggingPkgs",
+    ]
+    res = subprocess.run(
+        cmd,
+        cwd=TEST_ROOT.joinpath("assets"),
+        text=True,
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    results = {r["attr"]: r for r in map(json.loads, res.stdout.splitlines())}
+    assert results["warns"]["warnings"] == ["first warning", "second warning"]
+    assert "traces" not in results["warns"]
+    assert results["traces"]["traces"] == ["hello from trace"]
+    assert "warnings" not in results["traces"]
+    assert "warnings" not in results["quiet"]
+    assert "traces" not in results["quiet"]
+    assert results["warnThenThrow"]["warnings"] == ["about to fail"]
+    assert "failed" in results["warnThenThrow"]["error"]
+
+
 def test_no_gcroot_dir() -> None:
     cmd = [
         str(BIN),

--- a/tests-unit/data/response/error-with-logs.json
+++ b/tests-unit/data/response/error-with-logs.json
@@ -1,0 +1,15 @@
+{
+  "attr": "broken",
+  "attrPath": [
+    "broken"
+  ],
+  "error": "evaluation failed",
+  "fatal": false,
+  "traces": [
+    "got here"
+  ],
+  "warnings": [
+    "deprecated",
+    "also deprecated"
+  ]
+}

--- a/tests-unit/json.cc
+++ b/tests-unit/json.cc
@@ -290,6 +290,16 @@ INSTANTIATE_TEST_SUITE_P(
                 .attrPath = {"broken"},
                 .payload = Response::Error{.error = "evaluation failed"},
             },
+        },
+        std::pair{
+            "error-with-logs",
+            Response{
+                .attr = "broken",
+                .attrPath = {"broken"},
+                .payload = Response::Error{.error = "evaluation failed"},
+                .warnings = {"deprecated", "also deprecated"},
+                .traces = {"got here"},
+            },
         }));
 
 // NOLINTEND(google-readability-avoid-underscore-in-googletest-name)


### PR DESCRIPTION
With several workers the stderr output of `builtins.warn` and `builtins.trace` is interleaved and cannot be attributed to an attribute. The worker now wraps its logger, collects those messages per job and sends them along as `"warnings": [..]` and `"traces": [..]` (omitted when empty). stderr output is unchanged.

Compared to #396 and #409 this is one small Logger decorator (`src/eval-log.{hh,cc}`) hooked into the existing `Response` type, without a new CLI flag, mutexes, or the abort-on-warn trace heuristics. Shared thunks only log once, so a message is reported on whichever attribute forced it first (documented in the README).

Supersedes #396 and #409.
