### PR TITLE
Link against mimalloc like the nix binary does

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation {
     nixComponents.nix-util-test-support
   ];
   buildInputs = with pkgs; [
+    mimalloc
     nlohmann_json
     boost
     curl

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,8 @@ threads_dep = dependency('threads', required: true)
 nlohmann_json_dep = dependency('nlohmann_json', required: true)
 boost_dep = dependency('boost', required: true)
 libcurl_dep = dependency('libcurl', required: true)
+# Same allocator as the nix binary. Listed first so it overrides malloc.
+mimalloc_dep = dependency('mimalloc', required: true)
 
 nix_store_dep = dependency('nix-store', required: true)
 nix_fetchers_dep = dependency('nix-fetchers', required: true)

--- a/src/meson.build
+++ b/src/meson.build
@@ -42,6 +42,6 @@ nix_eval_jobs_dep = declare_dependency(
 executable(
   'nix-eval-jobs',
   'nix-eval-jobs.cc',
-  dependencies: [nix_eval_jobs_dep],
+  dependencies: [mimalloc_dep, nix_eval_jobs_dep],
   install: true,
 )


### PR DESCRIPTION
Same allocator as upstream nix 2.35, which links its CLI against mimalloc for faster evaluation.