### PR TITLE
Report per-attribute eval stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ evaluated, as `"warnings": [...]` and `"traces": [...]` (omitted when empty).
 Because Nix evaluates shared values only once, a message from code shared
 between attributes is reported on whichever attribute forced it first.
 
+### How expensive was an attribute to evaluate?
+
+Every JSON line carries `"stats": {"wallMs": ..., "allocBytes": ...}` with the
+wall-clock time and the number of bytes allocated on the GC heap while the
+worker evaluated that attribute. As with warnings, values shared between
+attributes are only evaluated once and are billed to whichever attribute forced
+them first, so the numbers depend on scheduling order and are best used to spot
+outliers rather than for exact accounting.
+
 ### How can I evaluate nixpkgs?
 
 If you want to evaluate nixpkgs in the same way

--- a/src/response.cc
+++ b/src/response.cc
@@ -62,6 +62,7 @@ using nix::get;
 using nix::getBoolean;
 using nix::getObject;
 using nix::getString;
+using nix::getUnsigned;
 using nix::overloaded;
 using nix::valueAt;
 
@@ -75,6 +76,12 @@ void adl_serializer<Response>::to_json(json &res, const Response &response) {
     }
     if (!response.traces.empty()) {
         res["traces"] = response.traces;
+    }
+    if (response.stats) {
+        res["stats"] = json{
+            {"wallMs", response.stats->wallMs},
+            {"allocBytes", response.stats->allocBytes},
+        };
     }
 
     std::visit(overloaded{
@@ -107,6 +114,13 @@ auto adl_serializer<Response>::from_json(const json &_json) -> Response {
         return v ? v->get<std::vector<std::string>>()
                  : std::vector<std::string>{};
     };
+    std::optional<Response::Stats> stats;
+    if (const auto *s = get(json, "stats")) {
+        stats = Response::Stats{
+            .wallMs = getUnsigned(valueAt(getObject(*s), "wallMs")),
+            .allocBytes = getUnsigned(valueAt(getObject(*s), "allocBytes")),
+        };
+    }
     auto makeResponse = [&](Response::Payload payload) -> Response {
         return Response{
             .attr = std::move(attr),
@@ -114,6 +128,7 @@ auto adl_serializer<Response>::from_json(const json &_json) -> Response {
             .payload = std::move(payload),
             .warnings = stringList("warnings"),
             .traces = stringList("traces"),
+            .stats = stats,
         };
     };
 

--- a/src/response.hh
+++ b/src/response.hh
@@ -5,6 +5,7 @@
 #include <nlohmann/json_fwd.hpp>
 // Required for std::optional<nlohmann::json>
 #include <nlohmann/json.hpp> //NOLINT(misc-include-cleaner)
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <variant>
@@ -52,6 +53,15 @@ struct Response {
        so a message shows up on whichever attribute got there first. */
     std::vector<std::string> warnings = {};
     std::vector<std::string> traces = {};
+
+    /* Cost of evaluating this attribute in the worker. Like warnings,
+       shared thunks are billed to whichever attribute forced them first. */
+    struct Stats {
+        uint64_t wallMs = 0;
+        uint64_t allocBytes = 0; // GC allocations, 0 without Boehm
+        bool operator==(const Stats &) const = default;
+    };
+    std::optional<Stats> stats = {};
 
     bool operator==(const Response &) const = default;
 };

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -16,12 +16,15 @@
 #include <stdlib.h>
 // NOLINTEND(modernize-deprecated-headers)
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
 #include <exception>
 #include <filesystem>
 #include <nix/expr/attr-set.hh>
 #include <nix/cmd/common-eval-args.hh>
 #include <nix/util/error.hh>
 #include <nix/expr/eval.hh>
+#include <nix/expr/eval-gc.hh>
 #include <nix/util/file-system.hh>
 #include <nix/fetchers/attrs.hh>
 #include <nix/flake/flakeref.hh>
@@ -359,6 +362,17 @@ struct Evaluator {
 
 enum class Next { Job, Exit, Restart };
 
+auto gcAllocatedBytes() -> uint64_t {
+#if NIX_USE_BOEHMGC
+    GC_word heapSize = 0;
+    GC_word totalBytes = 0;
+    GC_get_heap_usage_safe(&heapSize, nullptr, nullptr, nullptr, &totalBytes);
+    return totalBytes;
+#else
+    return 0;
+#endif
+}
+
 /* One request/response round with the collector. */
 auto processJobRequest(Evaluator &evaluator, LineReader &fromReader,
                        nix::AutoCloseFD &toParent) -> Next {
@@ -379,7 +393,16 @@ auto processJobRequest(Evaluator &evaluator, LineReader &fromReader,
     }
 
     evaluator.logCapture.take(); // drop noise from between jobs
+    const auto startTime = std::chrono::steady_clock::now();
+    const auto startAlloc = gcAllocatedBytes();
     auto payload = evaluator.evaluate(path);
+    const Response::Stats stats{
+        .wallMs = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - startTime)
+                .count()),
+        .allocBytes = gcAllocatedBytes() - startAlloc,
+    };
     auto logs = evaluator.logCapture.take();
     const Response response{
         .attr = joinAttrPath(path),
@@ -387,6 +410,7 @@ auto processJobRequest(Evaluator &evaluator, LineReader &fromReader,
         .payload = std::move(payload),
         .warnings = std::move(logs.warnings),
         .traces = std::move(logs.traces),
+        .stats = stats,
     };
     if (tryWriteLine(toParent.get(), nlohmann::json(response).dump()) < 0) {
         return Next::Exit;

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -66,6 +66,11 @@ def common_test(extra_args: list[str]) -> list[dict[str, Any]]:
         recurse_drv = by_attr["recurse.drvB"]
         assert recurse_drv["name"] == "drvB"
 
+        for r in results:
+            stats = r["stats"]
+            assert stats["wallMs"] >= 0
+            assert stats["allocBytes"] > 0
+
         assert len(list(Path(tempdir).iterdir())) == 4
         return results
 

--- a/tests-unit/data/response/attrs-with-stats.json
+++ b/tests-unit/data/response/attrs-with-stats.json
@@ -1,0 +1,13 @@
+{
+  "attr": "pkgs",
+  "attrPath": [
+    "pkgs"
+  ],
+  "attrs": [
+    "foo"
+  ],
+  "stats": {
+    "allocBytes": 4096,
+    "wallMs": 12
+  }
+}

--- a/tests-unit/json.cc
+++ b/tests-unit/json.cc
@@ -300,6 +300,15 @@ INSTANTIATE_TEST_SUITE_P(
                 .warnings = {"deprecated", "also deprecated"},
                 .traces = {"got here"},
             },
+        },
+        std::pair{
+            "attrs-with-stats",
+            Response{
+                .attr = "pkgs",
+                .attrPath = {"pkgs"},
+                .payload = Response::Attrs{.attrs = {"foo"}},
+                .stats = Response::Stats{.wallMs = 12, .allocBytes = 4096},
+            },
         }));
 
 // NOLINTEND(google-readability-avoid-underscore-in-googletest-name)


### PR DESCRIPTION
Consumers want to show how long evaluation took and which attributes are expensive (Mic92/nixbot#162).
The worker already knows this, so attach wall time and GC bytes allocated while evaluating each
attribute as a "stats" object on every JSON line.

allocBytes uses the collector's monotonic total-bytes counter rather
than heap size or RSS: it is byte-granular and unaffected by heap
expansion chunks, page cache or other workers. Shared thunks are billed
to the first attribute that forces them, same as warnings/traces.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
drv: read derivations through the daemon store again (<a href="https://github.com/NixOS/nix-eval-jobs/pull/463">#463</a>)
</summary>
2063c91 skipped every RemoteStore, but UDSRemoteStore is also a
LocalFSStore and reads .drv files locally. This dropped
requiredSystemFeatures/inputDrvs on multi-user installs. Only skip
remote stores without local filesystem access.
</details>
</details>
</details>