### PR TITLE
[need #462] drv: read derivations through the daemon store again

### DIFF
--- a/src/drv.cc
+++ b/src/drv.cc
@@ -127,13 +127,14 @@ auto Drv::fromPackageInfo(std::string &attrPath, nix::EvalState &state,
         .constituents = std::move(constituents),
     };
 
-    /* Reading the derivation is cheap except through a daemon
-       connection, so RemoteStore keeps the fallback. A store that
+    /* Skip stores that would read the .drv over the wire. The daemon
+       (UDSRemoteStore) is a LocalFSStore and reads locally. A store that
        fails to read is remembered. */
     static std::atomic<bool> storeReadsDrvs = true;
+    const bool overTheWire = store.dynamic_pointer_cast<nix::RemoteStore>() &&
+                             !store.dynamic_pointer_cast<nix::LocalFSStore>();
     const bool tryReadDerivation =
-        !nix::settings.readOnlyMode && storeReadsDrvs &&
-        !store.dynamic_pointer_cast<nix::RemoteStore>();
+        !nix::settings.readOnlyMode && storeReadsDrvs && !overTheWire;
 
     bool precise = false;
     if (tryReadDerivation) {


### PR DESCRIPTION
2063c91 skipped every RemoteStore, but UDSRemoteStore is also a
LocalFSStore and reads .drv files locally. This dropped
requiredSystemFeatures/inputDrvs on multi-user installs. Only skip
remote stores without local filesystem access.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
Report per-attribute eval stats (<a href="https://github.com/NixOS/nix-eval-jobs/pull/462">#462</a>)
</summary>
Consumers want to show how long evaluation took and which attributes are expensive (Mic92/nixbot#162).
The worker already knows this, so attach wall time and GC bytes allocated while evaluating each
attribute as a "stats" object on every JSON line.

allocBytes uses the collector's monotonic total-bytes counter rather
than heap size or RSS: it is byte-granular and unaffected by heap
expansion chunks, page cache or other workers. Shared thunks are billed
to the first attribute that forces them, same as warnings/traces.
</details>
</details>
</details>