### PR TITLE
flake: drop flake-parts

### DIFF
--- a/dev/clang-tidy.nix
+++ b/dev/clang-tidy.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  nix-eval-jobs,
+  git,
+  llvmPackages,
+}:
+nix-eval-jobs.overrideAttrs (old: {
+  pname = "nix-eval-jobs-clang-tidy";
+  nativeBuildInputs = old.nativeBuildInputs ++ [
+    git
+    (lib.hiPrio llvmPackages.clang-tools)
+  ];
+  buildPhase = ''
+    export HOME=$TMPDIR
+    cat > $HOME/.gitconfig <<EOF
+    [user]
+      name = Nix
+      email = nix@localhost
+    [init]
+      defaultBranch = main
+    EOF
+    pushd ..
+    git init
+    git add .
+    git commit -m init --quiet
+    popd
+    echo "Verifying clang-tidy configuration..."
+    clang-tidy --verify-config
+    ninja clang-tidy-fix
+    git status
+    if ! git --no-pager diff --exit-code; then
+      echo "clang-tidy-fix failed, please run `ninja clang-tidy-fix` and commit the changes"
+      exit 1
+    fi
+  '';
+  installPhase = ''
+    touch $out
+  '';
+})

--- a/dev/functional-tests.nix
+++ b/dev/functional-tests.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  runCommand,
+  nix-eval-jobs,
+  python3,
+  nix,
+  gitMinimal,
+}:
+runCommand "nix-eval-jobs-functional-tests"
+  {
+    src = lib.fileset.toSource {
+      fileset = ../tests-functional;
+      root = ../.;
+    };
+    nativeBuildInputs = [
+      nix-eval-jobs
+      python3.pkgs.pytest
+      nix
+      gitMinimal
+    ];
+  }
+  ''
+    cp -r $src/tests-functional .
+
+    export HOME=$TMPDIR
+    export NIX_STATE_DIR=$TMPDIR/nix-state
+    export NIX_STORE_DIR=$TMPDIR/nix-store
+    export NIX_DATA_DIR=$TMPDIR/nix-data
+    export NIX_LOG_DIR=$TMPDIR/nix-log
+    export NIX_CONF_DIR=$TMPDIR/nix-conf
+    export NIX_EVAL_JOBS_BIN=${nix-eval-jobs}/bin/nix-eval-jobs
+
+    pytest tests-functional/ -v
+    touch $out
+  ''

--- a/dev/nix-scope.nix
+++ b/dev/nix-scope.nix
@@ -1,0 +1,56 @@
+# Package scope with Nix's own dependency overrides and components, so
+# nix-eval-jobs links against exactly the libraries Nix was built with.
+# Everything the flake exposes is a member of this scope.
+{
+  pkgs,
+  lib,
+  nix,
+  treefmt-nix,
+  self,
+}:
+let
+  nixDependencies = lib.makeScope pkgs.newScope (
+    scope:
+    let
+      super = import (nix + "/packaging/dependencies.nix") {
+        inherit pkgs;
+        inherit (pkgs) stdenv;
+        inputs = { };
+      } scope;
+    in
+    super
+    // {
+      # `dependencies.nix` patches boost for
+      # https://github.com/NixOS/nix/issues/16174, but the nixpkgs we
+      # track already backports that commit (boostorg/context@5883212),
+      # so cut the extra patches.
+      #
+      # FIXME avoid messing up in Nix itself instead.
+      boost = super.boost.overrideAttrs (_: {
+        patches = pkgs.boost.patches;
+      });
+
+      nixComponents = lib.makeScope scope.newScope (
+        import (nix + "/packaging/components.nix") {
+          officialRelease = true;
+          inherit lib pkgs;
+          src = nix;
+          maintainers = [ ];
+        }
+      );
+
+      nix-eval-jobs = scope.callPackage ../default.nix { };
+      clangStdenv-nix-eval-jobs = scope.callPackage ../default.nix { stdenv = pkgs.clangStdenv; };
+
+      shell = scope.callPackage ../shell.nix { };
+      clangShell = scope.callPackage ../shell.nix { stdenv = pkgs.clangStdenv; };
+
+      treefmt = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+      treefmtCheck = scope.treefmt.config.build.check self;
+      scheduler-spec = scope.callPackage ./scheduler-spec.nix { };
+      functional-tests = scope.callPackage ./functional-tests.nix { };
+      clang-tidy-fix = scope.callPackage ./clang-tidy.nix { };
+    }
+  );
+in
+nixDependencies

--- a/dev/scheduler-spec.nix
+++ b/dev/scheduler-spec.nix
@@ -1,0 +1,9 @@
+{ runCommand, quint }:
+runCommand "nix-eval-jobs-scheduler-spec" { nativeBuildInputs = [ quint ]; } ''
+  export HOME=$TMPDIR
+  cd ${../spec}
+  quint run scheduler.qnt --main main --invariant inv --max-steps 150 --max-samples 2000
+  quint test scheduler.qnt --main noOomKiller --max-samples 200
+  quint test scheduler.qnt --main main --match terminates --max-samples 200
+  touch $out
+''

--- a/dev/treefmt.nix
+++ b/dev/treefmt.nix
@@ -5,7 +5,6 @@ let
     && (builtins.tryEval pkgs.deno.outPath).success;
 in
 {
-  flakeCheck = pkgs.stdenv.hostPlatform.system != "riscv64-linux";
   # Used to find the project root
   projectRootFile = "flake.lock";
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1765835352,
-        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nix": {
       "flake": false,
       "locked": {
@@ -52,7 +32,6 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nix": "nix",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -26,170 +26,48 @@
 
         "aarch64-darwin"
       ];
-      eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system} system);
-
-      scopeFor =
-        pkgs:
-        let
-          nixDependencies = lib.makeScope pkgs.newScope (
-            scope:
-            let
-              super = import (nix + "/packaging/dependencies.nix") {
-                inherit pkgs;
-                inherit (pkgs) stdenv;
-                inputs = { };
-              } scope;
-            in
-            super
-            // {
-              # `dependencies.nix` patches boost for
-              # https://github.com/NixOS/nix/issues/16174, but the nixpkgs we
-              # track already backports that commit (boostorg/context@5883212),
-              # so cut the extra patches.
-              #
-              # FIXME avoid messing up in Nix itself instead.
-              boost = super.boost.overrideAttrs (_: {
-                patches = pkgs.boost.patches;
-              });
+      eachSystem =
+        f:
+        lib.genAttrs systems (
+          system:
+          f system (
+            nixpkgs.legacyPackages.${system}.callPackage ./dev/nix-scope.nix {
+              inherit nix treefmt-nix self;
             }
-          );
-          nixComponents = lib.makeScope nixDependencies.newScope (
-            import (nix + "/packaging/components.nix") {
-              officialRelease = true;
-              inherit lib pkgs;
-              src = nix;
-              maintainers = [ ];
-            }
-          );
-        in
-        {
-          inherit (nixDependencies) callPackage;
-          drvArgs = { inherit nixComponents; };
-        };
-
-      treefmtFor = pkgs: treefmt-nix.lib.evalModule pkgs ./dev/treefmt.nix;
+          )
+        );
     in
     {
       packages = eachSystem (
-        pkgs: system:
-        let
-          inherit (scopeFor pkgs) callPackage drvArgs;
-        in
-        {
-          nix-eval-jobs = callPackage ./default.nix drvArgs;
-          clangStdenv-nix-eval-jobs = callPackage ./default.nix (drvArgs // { stdenv = pkgs.clangStdenv; });
-          default = self.packages.${system}.nix-eval-jobs;
+        _system: scope: {
+          inherit (scope) nix-eval-jobs clangStdenv-nix-eval-jobs;
+          default = scope.nix-eval-jobs;
         }
       );
 
       devShells = eachSystem (
-        pkgs: _system:
-        let
-          inherit (scopeFor pkgs) callPackage drvArgs;
-        in
-        {
-          default = callPackage ./shell.nix drvArgs;
-          clang = callPackage ./shell.nix (drvArgs // { stdenv = pkgs.clangStdenv; });
+        _system: scope: {
+          default = scope.shell;
+          clang = scope.clangShell;
         }
       );
 
-      formatter = eachSystem (pkgs: _system: (treefmtFor pkgs).config.build.wrapper);
+      formatter = eachSystem (_system: scope: scope.treefmt.config.build.wrapper);
 
       checks = eachSystem (
-        pkgs: system:
-        let
-          self' = {
-            packages = self.packages.${system};
-            devShells = self.devShells.${system};
-          };
-        in
-        builtins.removeAttrs self'.packages [ "default" ]
-        // lib.optionalAttrs (system != "riscv64-linux") {
-          treefmt = (treefmtFor pkgs).config.build.check self;
+        system: scope:
+        {
+          inherit (scope)
+            nix-eval-jobs
+            clangStdenv-nix-eval-jobs
+            shell
+            scheduler-spec
+            functional-tests
+            clang-tidy-fix
+            ;
         }
-        // {
-          shell = self'.devShells.default;
-          scheduler-spec =
-            pkgs.runCommand "nix-eval-jobs-scheduler-spec" { nativeBuildInputs = [ pkgs.quint ]; }
-              ''
-                  export HOME=$TMPDIR
-                  cd ${./spec}
-                  quint run scheduler.qnt --main main --invariant inv --max-steps 150 --max-samples 2000
-                  quint test scheduler.qnt --main noOomKiller --max-samples 200
-                quint test scheduler.qnt --main main --match terminates --max-samples 200
-                  touch $out
-              '';
-          functional-tests =
-            pkgs.runCommand "nix-eval-jobs-functional-tests"
-              {
-                src = lib.fileset.toSource {
-                  fileset = lib.fileset.unions [
-                    ./tests-functional
-                  ];
-                  root = ./.;
-                };
-
-                nativeBuildInputs = [
-                  self'.packages.nix-eval-jobs
-                  pkgs.python3.pkgs.pytest
-                  pkgs.nix
-                  pkgs.gitMinimal
-                ];
-              }
-              ''
-                # Copy test files
-                cp -r $src/tests-functional .
-
-                # Set up test environment
-                export HOME=$TMPDIR
-                export NIX_STATE_DIR=$TMPDIR/nix-state
-                export NIX_STORE_DIR=$TMPDIR/nix-store
-                export NIX_DATA_DIR=$TMPDIR/nix-data
-                export NIX_LOG_DIR=$TMPDIR/nix-log
-                export NIX_CONF_DIR=$TMPDIR/nix-conf
-
-                # Use the pre-built nix-eval-jobs binary
-                export NIX_EVAL_JOBS_BIN=${self'.packages.nix-eval-jobs}/bin/nix-eval-jobs
-
-                # Run the tests
-                pytest tests-functional/ -v
-
-                # Create output marker
-                touch $out
-              '';
-          clang-tidy-fix = self'.packages.nix-eval-jobs.overrideAttrs (old: {
-            pname = "nix-eval-jobs-clang-tidy";
-            nativeBuildInputs = old.nativeBuildInputs ++ [
-              pkgs.git
-              (lib.hiPrio pkgs.llvmPackages.clang-tools)
-            ];
-            buildPhase = ''
-              export HOME=$TMPDIR
-              cat > $HOME/.gitconfig <<EOF
-              [user]
-                name = Nix
-                email = nix@localhost
-              [init]
-                defaultBranch = main
-              EOF
-              pushd ..
-              git init
-              git add .
-              git commit -m init --quiet
-              popd
-              echo "Verifying clang-tidy configuration..."
-              clang-tidy --verify-config
-              ninja clang-tidy-fix
-              git status
-              if ! git --no-pager diff --exit-code; then
-                echo "clang-tidy-fix failed, please run `ninja clang-tidy-fix` and commit the changes"
-                exit 1
-              fi
-            '';
-            installPhase = ''
-              touch $out
-            '';
-          });
+        // lib.optionalAttrs (system != "riscv64-linux") {
+          treefmt = scope.treefmtCheck;
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -7,17 +7,18 @@
     # We want to control the deps precisely
     flake = false;
   };
-  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
-  inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
   inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
   inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    inputs@{ flake-parts, ... }:
+    {
+      self,
+      nixpkgs,
+      nix,
+      treefmt-nix,
+    }:
     let
-      inherit (inputs.nixpkgs) lib;
-    in
-    flake-parts.lib.mkFlake { inherit inputs; } {
+      inherit (nixpkgs) lib;
       systems = [
         "aarch64-linux"
         "riscv64-linux"
@@ -25,15 +26,15 @@
 
         "aarch64-darwin"
       ];
-      imports = [ inputs.treefmt-nix.flakeModule ];
+      eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system} system);
 
-      perSystem =
-        { pkgs, self', ... }:
+      scopeFor =
+        pkgs:
         let
           nixDependencies = lib.makeScope pkgs.newScope (
             scope:
             let
-              super = import (inputs.nix + "/packaging/dependencies.nix") {
+              super = import (nix + "/packaging/dependencies.nix") {
                 inherit pkgs;
                 inherit (pkgs) stdenv;
                 inputs = { };
@@ -53,113 +54,143 @@
             }
           );
           nixComponents = lib.makeScope nixDependencies.newScope (
-            import (inputs.nix + "/packaging/components.nix") {
+            import (nix + "/packaging/components.nix") {
               officialRelease = true;
               inherit lib pkgs;
-              src = inputs.nix;
+              src = nix;
               maintainers = [ ];
             }
           );
-          drvArgs = {
-            inherit nixComponents;
-          };
         in
         {
-          treefmt.imports = [ ./dev/treefmt.nix ];
-          packages.nix-eval-jobs = nixDependencies.callPackage ./default.nix drvArgs;
-          packages.clangStdenv-nix-eval-jobs = nixDependencies.callPackage ./default.nix (
-            drvArgs // { stdenv = pkgs.clangStdenv; }
-          );
-          packages.default = self'.packages.nix-eval-jobs;
-          devShells.default = nixDependencies.callPackage ./shell.nix drvArgs;
-          devShells.clang = nixDependencies.callPackage ./shell.nix (
-            drvArgs // { stdenv = pkgs.clangStdenv; }
-          );
+          inherit (nixDependencies) callPackage;
+          drvArgs = { inherit nixComponents; };
+        };
 
-          checks = builtins.removeAttrs self'.packages [ "default" ] // {
-            shell = self'.devShells.default;
-            scheduler-spec =
-              pkgs.runCommand "nix-eval-jobs-scheduler-spec" { nativeBuildInputs = [ pkgs.quint ]; }
-                ''
-                    export HOME=$TMPDIR
-                    cd ${./spec}
-                    quint run scheduler.qnt --main main --invariant inv --max-steps 150 --max-samples 2000
-                    quint test scheduler.qnt --main noOomKiller --max-samples 200
-                  quint test scheduler.qnt --main main --match terminates --max-samples 200
-                    touch $out
-                '';
-            functional-tests =
-              pkgs.runCommand "nix-eval-jobs-functional-tests"
-                {
-                  src = lib.fileset.toSource {
-                    fileset = lib.fileset.unions [
-                      ./tests-functional
-                    ];
-                    root = ./.;
-                  };
+      treefmtFor = pkgs: treefmt-nix.lib.evalModule pkgs ./dev/treefmt.nix;
+    in
+    {
+      packages = eachSystem (
+        pkgs: system:
+        let
+          inherit (scopeFor pkgs) callPackage drvArgs;
+        in
+        {
+          nix-eval-jobs = callPackage ./default.nix drvArgs;
+          clangStdenv-nix-eval-jobs = callPackage ./default.nix (drvArgs // { stdenv = pkgs.clangStdenv; });
+          default = self.packages.${system}.nix-eval-jobs;
+        }
+      );
 
-                  nativeBuildInputs = [
-                    self'.packages.nix-eval-jobs
-                    pkgs.python3.pkgs.pytest
-                    pkgs.nix
-                    pkgs.gitMinimal
-                  ];
-                }
-                ''
-                  # Copy test files
-                  cp -r $src/tests-functional .
+      devShells = eachSystem (
+        pkgs: _system:
+        let
+          inherit (scopeFor pkgs) callPackage drvArgs;
+        in
+        {
+          default = callPackage ./shell.nix drvArgs;
+          clang = callPackage ./shell.nix (drvArgs // { stdenv = pkgs.clangStdenv; });
+        }
+      );
 
-                  # Set up test environment
+      formatter = eachSystem (pkgs: _system: (treefmtFor pkgs).config.build.wrapper);
+
+      checks = eachSystem (
+        pkgs: system:
+        let
+          self' = {
+            packages = self.packages.${system};
+            devShells = self.devShells.${system};
+          };
+        in
+        builtins.removeAttrs self'.packages [ "default" ]
+        // lib.optionalAttrs (system != "riscv64-linux") {
+          treefmt = (treefmtFor pkgs).config.build.check self;
+        }
+        // {
+          shell = self'.devShells.default;
+          scheduler-spec =
+            pkgs.runCommand "nix-eval-jobs-scheduler-spec" { nativeBuildInputs = [ pkgs.quint ]; }
+              ''
                   export HOME=$TMPDIR
-                  export NIX_STATE_DIR=$TMPDIR/nix-state
-                  export NIX_STORE_DIR=$TMPDIR/nix-store
-                  export NIX_DATA_DIR=$TMPDIR/nix-data
-                  export NIX_LOG_DIR=$TMPDIR/nix-log
-                  export NIX_CONF_DIR=$TMPDIR/nix-conf
-
-                  # Use the pre-built nix-eval-jobs binary
-                  export NIX_EVAL_JOBS_BIN=${self'.packages.nix-eval-jobs}/bin/nix-eval-jobs
-
-                  # Run the tests
-                  pytest tests-functional/ -v
-
-                  # Create output marker
+                  cd ${./spec}
+                  quint run scheduler.qnt --main main --invariant inv --max-steps 150 --max-samples 2000
+                  quint test scheduler.qnt --main noOomKiller --max-samples 200
+                quint test scheduler.qnt --main main --match terminates --max-samples 200
                   touch $out
-                '';
-            clang-tidy-fix = self'.packages.nix-eval-jobs.overrideAttrs (old: {
-              pname = "nix-eval-jobs-clang-tidy";
-              nativeBuildInputs = old.nativeBuildInputs ++ [
-                pkgs.git
-                (lib.hiPrio pkgs.llvmPackages.clang-tools)
-              ];
-              buildPhase = ''
-                export HOME=$TMPDIR
-                cat > $HOME/.gitconfig <<EOF
-                [user]
-                  name = Nix
-                  email = nix@localhost
-                [init]
-                  defaultBranch = main
-                EOF
-                pushd ..
-                git init
-                git add .
-                git commit -m init --quiet
-                popd
-                echo "Verifying clang-tidy configuration..."
-                clang-tidy --verify-config
-                ninja clang-tidy-fix
-                git status
-                if ! git --no-pager diff --exit-code; then
-                  echo "clang-tidy-fix failed, please run `ninja clang-tidy-fix` and commit the changes"
-                  exit 1
-                fi
               '';
-              installPhase = ''
+          functional-tests =
+            pkgs.runCommand "nix-eval-jobs-functional-tests"
+              {
+                src = lib.fileset.toSource {
+                  fileset = lib.fileset.unions [
+                    ./tests-functional
+                  ];
+                  root = ./.;
+                };
+
+                nativeBuildInputs = [
+                  self'.packages.nix-eval-jobs
+                  pkgs.python3.pkgs.pytest
+                  pkgs.nix
+                  pkgs.gitMinimal
+                ];
+              }
+              ''
+                # Copy test files
+                cp -r $src/tests-functional .
+
+                # Set up test environment
+                export HOME=$TMPDIR
+                export NIX_STATE_DIR=$TMPDIR/nix-state
+                export NIX_STORE_DIR=$TMPDIR/nix-store
+                export NIX_DATA_DIR=$TMPDIR/nix-data
+                export NIX_LOG_DIR=$TMPDIR/nix-log
+                export NIX_CONF_DIR=$TMPDIR/nix-conf
+
+                # Use the pre-built nix-eval-jobs binary
+                export NIX_EVAL_JOBS_BIN=${self'.packages.nix-eval-jobs}/bin/nix-eval-jobs
+
+                # Run the tests
+                pytest tests-functional/ -v
+
+                # Create output marker
                 touch $out
               '';
-            });
-          };
-        };
+          clang-tidy-fix = self'.packages.nix-eval-jobs.overrideAttrs (old: {
+            pname = "nix-eval-jobs-clang-tidy";
+            nativeBuildInputs = old.nativeBuildInputs ++ [
+              pkgs.git
+              (lib.hiPrio pkgs.llvmPackages.clang-tools)
+            ];
+            buildPhase = ''
+              export HOME=$TMPDIR
+              cat > $HOME/.gitconfig <<EOF
+              [user]
+                name = Nix
+                email = nix@localhost
+              [init]
+                defaultBranch = main
+              EOF
+              pushd ..
+              git init
+              git add .
+              git commit -m init --quiet
+              popd
+              echo "Verifying clang-tidy configuration..."
+              clang-tidy --verify-config
+              ninja clang-tidy-fix
+              git status
+              if ! git --no-pager diff --exit-code; then
+                echo "clang-tidy-fix failed, please run `ninja clang-tidy-fix` and commit the changes"
+                exit 1
+              fi
+            '';
+            installPhase = ''
+              touch $out
+            '';
+          });
+        }
+      );
     };
 }


### PR DESCRIPTION
One less input to update. The flake is small enough that genAttrs and
treefmt-nix.lib.evalModule cover everything we used it for.
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
flake: move everything into one package scope in dev/ (<a href="https://github.com/NixOS/nix-eval-jobs/pull/468">#468</a>)
</summary>
flake.nix is now only wiring: each output picks members from the scope
defined in dev/nix-scope.nix, which layers nix-eval-jobs, shells and
checks on top of Nix's dependency scope via callPackage.
</details>
</details>
</details>