### PR TITLE
[need #465] flake: move checks and nix scope into dev/*.nix

### DIFF
--- a/dev/clang-tidy.nix
+++ b/dev/clang-tidy.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  nix-eval-jobs,
+  git,
+  llvmPackages,
+}:
+nix-eval-jobs.overrideAttrs (old: {
+  pname = "nix-eval-jobs-clang-tidy";
+  nativeBuildInputs = old.nativeBuildInputs ++ [
+    git
+    (lib.hiPrio llvmPackages.clang-tools)
+  ];
+  buildPhase = ''
+    export HOME=$TMPDIR
+    cat > $HOME/.gitconfig <<EOF
+    [user]
+      name = Nix
+      email = nix@localhost
+    [init]
+      defaultBranch = main
+    EOF
+    pushd ..
+    git init
+    git add .
+    git commit -m init --quiet
+    popd
+    echo "Verifying clang-tidy configuration..."
+    clang-tidy --verify-config
+    ninja clang-tidy-fix
+    git status
+    if ! git --no-pager diff --exit-code; then
+      echo "clang-tidy-fix failed, please run `ninja clang-tidy-fix` and commit the changes"
+      exit 1
+    fi
+  '';
+  installPhase = ''
+    touch $out
+  '';
+})

--- a/dev/functional-tests.nix
+++ b/dev/functional-tests.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  runCommand,
+  nix-eval-jobs,
+  python3,
+  nix,
+  gitMinimal,
+}:
+runCommand "nix-eval-jobs-functional-tests"
+  {
+    src = lib.fileset.toSource {
+      fileset = ../tests-functional;
+      root = ../.;
+    };
+    nativeBuildInputs = [
+      nix-eval-jobs
+      python3.pkgs.pytest
+      nix
+      gitMinimal
+    ];
+  }
+  ''
+    cp -r $src/tests-functional .
+
+    export HOME=$TMPDIR
+    export NIX_STATE_DIR=$TMPDIR/nix-state
+    export NIX_STORE_DIR=$TMPDIR/nix-store
+    export NIX_DATA_DIR=$TMPDIR/nix-data
+    export NIX_LOG_DIR=$TMPDIR/nix-log
+    export NIX_CONF_DIR=$TMPDIR/nix-conf
+    export NIX_EVAL_JOBS_BIN=${nix-eval-jobs}/bin/nix-eval-jobs
+
+    pytest tests-functional/ -v
+    touch $out
+  ''

--- a/dev/nix-scope.nix
+++ b/dev/nix-scope.nix
@@ -1,0 +1,41 @@
+# Package scope with Nix's own dependency overrides and components, so
+# nix-eval-jobs links against exactly the libraries Nix was built with.
+{
+  pkgs,
+  lib,
+  nix,
+}:
+let
+  nixDependencies = lib.makeScope pkgs.newScope (
+    scope:
+    let
+      super = import (nix + "/packaging/dependencies.nix") {
+        inherit pkgs;
+        inherit (pkgs) stdenv;
+        inputs = { };
+      } scope;
+    in
+    super
+    // {
+      # `dependencies.nix` patches boost for
+      # https://github.com/NixOS/nix/issues/16174, but the nixpkgs we
+      # track already backports that commit (boostorg/context@5883212),
+      # so cut the extra patches.
+      #
+      # FIXME avoid messing up in Nix itself instead.
+      boost = super.boost.overrideAttrs (_: {
+        patches = pkgs.boost.patches;
+      });
+
+      nixComponents = lib.makeScope scope.newScope (
+        import (nix + "/packaging/components.nix") {
+          officialRelease = true;
+          inherit lib pkgs;
+          src = nix;
+          maintainers = [ ];
+        }
+      );
+    }
+  );
+in
+nixDependencies

--- a/dev/scheduler-spec.nix
+++ b/dev/scheduler-spec.nix
@@ -1,0 +1,9 @@
+{ runCommand, quint }:
+runCommand "nix-eval-jobs-scheduler-spec" { nativeBuildInputs = [ quint ]; } ''
+  export HOME=$TMPDIR
+  cd ${../spec}
+  quint run scheduler.qnt --main main --invariant inv --max-steps 150 --max-samples 2000
+  quint test scheduler.qnt --main noOomKiller --max-samples 200
+  quint test scheduler.qnt --main main --match terminates --max-samples 200
+  touch $out
+''

--- a/flake.nix
+++ b/flake.nix
@@ -26,170 +26,60 @@
 
         "aarch64-darwin"
       ];
-      eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system} system);
-
-      scopeFor =
-        pkgs:
-        let
-          nixDependencies = lib.makeScope pkgs.newScope (
-            scope:
-            let
-              super = import (nix + "/packaging/dependencies.nix") {
-                inherit pkgs;
-                inherit (pkgs) stdenv;
-                inputs = { };
-              } scope;
-            in
-            super
-            // {
-              # `dependencies.nix` patches boost for
-              # https://github.com/NixOS/nix/issues/16174, but the nixpkgs we
-              # track already backports that commit (boostorg/context@5883212),
-              # so cut the extra patches.
-              #
-              # FIXME avoid messing up in Nix itself instead.
-              boost = super.boost.overrideAttrs (_: {
-                patches = pkgs.boost.patches;
-              });
-            }
-          );
-          nixComponents = lib.makeScope nixDependencies.newScope (
-            import (nix + "/packaging/components.nix") {
-              officialRelease = true;
-              inherit lib pkgs;
-              src = nix;
-              maintainers = [ ];
-            }
-          );
-        in
-        {
-          inherit (nixDependencies) callPackage;
-          drvArgs = { inherit nixComponents; };
-        };
-
-      treefmtFor = pkgs: treefmt-nix.lib.evalModule pkgs ./dev/treefmt.nix;
+      eachSystem =
+        f:
+        lib.genAttrs systems (
+          system:
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+          in
+          f {
+            inherit system pkgs;
+            scope = pkgs.callPackage ./dev/nix-scope.nix { inherit nix; };
+            treefmt = treefmt-nix.lib.evalModule pkgs ./dev/treefmt.nix;
+          }
+        );
     in
     {
       packages = eachSystem (
-        pkgs: system:
-        let
-          inherit (scopeFor pkgs) callPackage drvArgs;
-        in
-        {
-          nix-eval-jobs = callPackage ./default.nix drvArgs;
-          clangStdenv-nix-eval-jobs = callPackage ./default.nix (drvArgs // { stdenv = pkgs.clangStdenv; });
-          default = self.packages.${system}.nix-eval-jobs;
+        { scope, pkgs, ... }:
+        rec {
+          nix-eval-jobs = scope.callPackage ./default.nix { };
+          clangStdenv-nix-eval-jobs = scope.callPackage ./default.nix { stdenv = pkgs.clangStdenv; };
+          default = nix-eval-jobs;
         }
       );
 
       devShells = eachSystem (
-        pkgs: _system:
-        let
-          inherit (scopeFor pkgs) callPackage drvArgs;
-        in
+        { scope, pkgs, ... }:
         {
-          default = callPackage ./shell.nix drvArgs;
-          clang = callPackage ./shell.nix (drvArgs // { stdenv = pkgs.clangStdenv; });
+          default = scope.callPackage ./shell.nix { };
+          clang = scope.callPackage ./shell.nix { stdenv = pkgs.clangStdenv; };
         }
       );
 
-      formatter = eachSystem (pkgs: _system: (treefmtFor pkgs).config.build.wrapper);
+      formatter = eachSystem ({ treefmt, ... }: treefmt.config.build.wrapper);
 
       checks = eachSystem (
-        pkgs: system:
+        {
+          system,
+          pkgs,
+          treefmt,
+          ...
+        }:
         let
-          self' = {
-            packages = self.packages.${system};
-            devShells = self.devShells.${system};
-          };
+          packages = self.packages.${system};
+          callPackage = lib.callPackageWith (pkgs // { inherit (packages) nix-eval-jobs; });
         in
-        builtins.removeAttrs self'.packages [ "default" ]
-        // lib.optionalAttrs (system != "riscv64-linux") {
-          treefmt = (treefmtFor pkgs).config.build.check self;
-        }
+        builtins.removeAttrs packages [ "default" ]
         // {
-          shell = self'.devShells.default;
-          scheduler-spec =
-            pkgs.runCommand "nix-eval-jobs-scheduler-spec" { nativeBuildInputs = [ pkgs.quint ]; }
-              ''
-                  export HOME=$TMPDIR
-                  cd ${./spec}
-                  quint run scheduler.qnt --main main --invariant inv --max-steps 150 --max-samples 2000
-                  quint test scheduler.qnt --main noOomKiller --max-samples 200
-                quint test scheduler.qnt --main main --match terminates --max-samples 200
-                  touch $out
-              '';
-          functional-tests =
-            pkgs.runCommand "nix-eval-jobs-functional-tests"
-              {
-                src = lib.fileset.toSource {
-                  fileset = lib.fileset.unions [
-                    ./tests-functional
-                  ];
-                  root = ./.;
-                };
-
-                nativeBuildInputs = [
-                  self'.packages.nix-eval-jobs
-                  pkgs.python3.pkgs.pytest
-                  pkgs.nix
-                  pkgs.gitMinimal
-                ];
-              }
-              ''
-                # Copy test files
-                cp -r $src/tests-functional .
-
-                # Set up test environment
-                export HOME=$TMPDIR
-                export NIX_STATE_DIR=$TMPDIR/nix-state
-                export NIX_STORE_DIR=$TMPDIR/nix-store
-                export NIX_DATA_DIR=$TMPDIR/nix-data
-                export NIX_LOG_DIR=$TMPDIR/nix-log
-                export NIX_CONF_DIR=$TMPDIR/nix-conf
-
-                # Use the pre-built nix-eval-jobs binary
-                export NIX_EVAL_JOBS_BIN=${self'.packages.nix-eval-jobs}/bin/nix-eval-jobs
-
-                # Run the tests
-                pytest tests-functional/ -v
-
-                # Create output marker
-                touch $out
-              '';
-          clang-tidy-fix = self'.packages.nix-eval-jobs.overrideAttrs (old: {
-            pname = "nix-eval-jobs-clang-tidy";
-            nativeBuildInputs = old.nativeBuildInputs ++ [
-              pkgs.git
-              (lib.hiPrio pkgs.llvmPackages.clang-tools)
-            ];
-            buildPhase = ''
-              export HOME=$TMPDIR
-              cat > $HOME/.gitconfig <<EOF
-              [user]
-                name = Nix
-                email = nix@localhost
-              [init]
-                defaultBranch = main
-              EOF
-              pushd ..
-              git init
-              git add .
-              git commit -m init --quiet
-              popd
-              echo "Verifying clang-tidy configuration..."
-              clang-tidy --verify-config
-              ninja clang-tidy-fix
-              git status
-              if ! git --no-pager diff --exit-code; then
-                echo "clang-tidy-fix failed, please run `ninja clang-tidy-fix` and commit the changes"
-                exit 1
-              fi
-            '';
-            installPhase = ''
-              touch $out
-            '';
-          });
+          shell = self.devShells.${system}.default;
+          scheduler-spec = callPackage ./dev/scheduler-spec.nix { };
+          functional-tests = callPackage ./dev/functional-tests.nix { };
+          clang-tidy-fix = callPackage ./dev/clang-tidy.nix { };
+        }
+        // lib.optionalAttrs (system != "riscv64-linux") {
+          treefmt = treefmt.config.build.check self;
         }
       );
     };


### PR DESCRIPTION
Keeps flake.nix to wiring only. nixComponents is now part of the scope
so default.nix and shell.nix get it through callPackage.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
flake: drop flake-parts (<a href="https://github.com/NixOS/nix-eval-jobs/pull/465">#465</a>)
</summary>
One less input to update. The flake is small enough that genAttrs and
treefmt-nix.lib.evalModule cover everything we used it for.
</details>
</details>
</details>